### PR TITLE
properly refreshing view user list after updates

### DIFF
--- a/frontend/s_a_m_e/lib/view_accounts.dart
+++ b/frontend/s_a_m_e/lib/view_accounts.dart
@@ -31,6 +31,23 @@ class _ViewAccountsState extends State<ViewAccounts> {
     });
   }
 
+  // below method runs to properly display users if updated/deleted by admin
+  void refreshUsers(info) async {
+    usersSearch = await FirebaseService().getAllUsers();
+    if (info[1] == "delete") {
+      usersSearch.removeWhere((item) => item.email == info[0]);
+    } else {
+      for (var user in usersSearch) {
+        if (user.email == info[0]) {
+          user.role = info[1];
+        }
+      }
+    }
+    setState(() {
+      displayedUsers = usersSearch;
+    });
+  }
+
   Future<List<UserClass>> getSearchedUsers(String input) async {
     try {
       List<UserClass> searchedUsers = [];
@@ -143,7 +160,7 @@ class _ViewAccountsState extends State<ViewAccounts> {
                                             " " +
                                             displayedUsers[index].lastName,
                                         email: displayedUsers[index].email,
-                                        role: displayedUsers[index].role)));
+                                        role: displayedUsers[index].role))).then((info) => refreshUsers(info));
                               },
                               child: Container(
                                 padding: const EdgeInsets.all(5),

--- a/frontend/s_a_m_e/lib/view_profile.dart
+++ b/frontend/s_a_m_e/lib/view_profile.dart
@@ -214,8 +214,7 @@ void confirmDeleteDialog(BuildContext context, String email) {
                   if (checkboxValue) {
                     FirebaseService().deleteUser(email);
                     Navigator.of(context).pop();
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pop([email, "delete"]); // passed in info for refreshUsers()
                   } else {
                     Fluttertoast.showToast(
                       msg: 'Please click the box to confirm your choice.',
@@ -320,8 +319,7 @@ void confirmEditDialog(BuildContext context, String email, String role, String n
                     _updateUserRole(context, email, role);
                     Navigator.of(context).pop();
                     Navigator.of(context).pop();
-                    Navigator.of(context).pop();
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pop([email, role]); // sending info for refreshUsers()
                   } else {
                     Fluttertoast.showToast(
                       msg: 'Please click the box to confirm your choice.',


### PR DESCRIPTION
Added function for view_accounts so when an admin edits role or deletes a user, they will be taken back to the view all users page and see the correct updates. Bit of a frontend workaround since Firebase was sending in the old data for some reason after updating roles and deleting users, but works how we want it to!