### PR TITLE
removing profile pictures before their rework

### DIFF
--- a/frontend/s_a_m_e/lib/add_category.dart
+++ b/frontend/s_a_m_e/lib/add_category.dart
@@ -30,7 +30,7 @@ class _CategoryCreationPage extends State<CategoryCreationPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('S.A.M.E'),
-        actions: [ProfilePicturePage()]
+        // actions: [ProfilePicturePage()]
       ),
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/frontend/s_a_m_e/lib/add_symptom.dart
+++ b/frontend/s_a_m_e/lib/add_symptom.dart
@@ -30,7 +30,7 @@ class _SymptomCreationPageState extends State<SymptomCreationPage> {
       appBar: AppBar(
         title: const Text('S.A.M.E'),
         // ignore: prefer_const_constructors, prefer_const_literals_to_create_immutables
-        actions: [ProfilePicturePage()]
+        // actions: [ProfilePicturePage()]
       ),
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/frontend/s_a_m_e/lib/adminrequest.dart
+++ b/frontend/s_a_m_e/lib/adminrequest.dart
@@ -36,7 +36,7 @@ class _AdminRequestPageState extends State<AdminRequestPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Admin Requests", style: TextStyle(fontSize: 36.0)),
-        actions: [ProfilePicturePage()],
+        // actions: [ProfilePicturePage()],
       ),
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/frontend/s_a_m_e/lib/categorieslist.dart
+++ b/frontend/s_a_m_e/lib/categorieslist.dart
@@ -24,7 +24,7 @@ class _CategoriesListPageState extends State<CategoriesListPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Categories", style: TextStyle(fontSize: 36.0)),
-        actions: const [ProfilePicturePage()],
+        // actions: const [ProfilePicturePage()],
       ),
       body: Padding(
         padding: const EdgeInsets.all(15.0),

--- a/frontend/s_a_m_e/lib/symptomlist.dart
+++ b/frontend/s_a_m_e/lib/symptomlist.dart
@@ -25,7 +25,7 @@ class _SymptomsListPageState extends State<SymptomsListPage> {
       appBar: AppBar(
         title: const Text("Symptoms", style: TextStyle(fontSize: 36.0)),
         // ignore: prefer_const_constructors, prefer_const_literals_to_create_immutables
-        actions: [ProfilePicturePage()]
+        // actions: [ProfilePicturePage()]
       ),
       body: Padding(
         padding: const EdgeInsets.all(15.0),


### PR DESCRIPTION
Quick edit before demo video to remove instances of profile pictures in top right corner not fully working. Not changing empty profile pictures in account or view users in admin as those are pretty core to their respective pages. 