### PR TITLE
SCRUM-143: Symptom Selection Page

### DIFF
--- a/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
+++ b/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
@@ -39,7 +39,7 @@ class _ChooseCategoryState extends State<ChooseCategory> {
               return Scrollbar(
                   trackVisibility: true,
                   child: GridView.builder(
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 2,
                       mainAxisSpacing: 15.0,
                       crossAxisSpacing: 15.0,

--- a/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
+++ b/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:s_a_m_e/colors.dart';
+import 'package:s_a_m_e/firebase/firebase_service.dart';
+
+class PotentialDiagnosis extends StatefulWidget {
+  const PotentialDiagnosis({super.key, required this.selectedSymptoms});
+
+  final List<Map<String, dynamic>> selectedSymptoms;
+
+  @override
+  State<PotentialDiagnosis> createState() => _PotentialDiagnosisState();
+}
+
+class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Potential Diagnosis", style: TextStyle(fontSize: 32.0),),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(15),
+        child: Column(
+          children: [
+            Text("${widget.selectedSymptoms}")
+          ],
+        ),
+      ),
+    );
+  }
+
+}
+
+

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -15,6 +15,8 @@ class SelectSymptom extends StatefulWidget {
 class _SelectSymptomState extends State<SelectSymptom> {
 
   // not totally sure if this is how it works
+  // display category selected at the top
+  // use ListTile object to display all of the symptoms able to be selected
 
   @override
   Widget build(BuildContext context) {
@@ -22,8 +24,16 @@ class _SelectSymptomState extends State<SelectSymptom> {
       appBar: AppBar(
         title: const Text("Select Symptoms", style: TextStyle(fontSize: 32.0)),
       ),
-      body: ListView(
-        children: [Text(widget.category.name), Text(widget.category.symptoms[0]), Text(widget.category.symptoms[1])],
+      body: Padding(
+        padding: const EdgeInsets.all(15),
+        child: Column(
+          children: [
+            Text("Category: $widget.category.name"),
+            ListView(
+              children: [Text(widget.category.name), Text(widget.category.symptoms[0]), Text(widget.category.symptoms[1])],
+            )
+          ],
+        ),
       )
     );
   }

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
@@ -14,9 +16,18 @@ class SelectSymptom extends StatefulWidget {
 
 class _SelectSymptomState extends State<SelectSymptom> {
 
-  // not totally sure if this is how it works
-  // display category selected at the top
-  // use ListTile object to display all of the symptoms able to be selected
+  List<bool> checked = [];
+  bool isChecked = false;
+  List<String> checkedItems = [];
+  List<Map<String, dynamic>> checkedSymptoms = [];
+
+  @override
+  void initState() {
+    super.initState();
+    for (int i = 0; i < widget.category.symptoms.length; i++) {
+      checkedSymptoms.add({"name": widget.category.symptoms[i], "isChecked": false});
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,12 +39,75 @@ class _SelectSymptomState extends State<SelectSymptom> {
         padding: const EdgeInsets.all(15),
         child: Column(
           children: [
-            Text("Category: $widget.category.name"),
-            ListView(
-              children: [Text(widget.category.name), Text(widget.category.symptoms[0]), Text(widget.category.symptoms[1])],
+            RichText(
+              text: TextSpan(
+                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
+                children: <TextSpan>[
+                  const TextSpan(text: "Category", style: TextStyle(fontWeight: FontWeight.bold)),
+                  TextSpan(text: ": ${widget.category.name}")
+                ]
+              )
+            ),
+            const SizedBox(height: 10),
+            const Divider(thickness: 2),
+            const SizedBox(height: 5),
+            SizedBox(
+              height: 200,
+              child: ListView.builder(
+                itemCount: widget.category.symptoms.length,
+                itemBuilder: (context, index) {
+                  if (widget.category.symptoms.isEmpty) {
+                    return const Center(child: Text('No Symptoms Found'));
+                  } else {
+                    return Column(
+                      children: [
+                        CheckboxListTile(
+                        value: isChecked,
+                        title: Text(widget.category.symptoms[index]),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        activeColor: navy,
+                        tileColor: boxinsides,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(15),
+                          side: const BorderSide(color: teal)
+                          ),
+                        onChanged: ((value) {
+                          setState(() {
+                            isChecked = value!;
+                            // if (value) {
+                            //   checkedItems.add(widget.category.symptoms[index]);
+                            // } else {
+                            //   if (checkedItems.contains(widget.category.symptoms[index])) {
+                            //     checkedItems.remove(widget.category.symptoms[index]);
+                            //   }
+                            // }
+                          });
+                        }),
+                      ),
+                      const SizedBox(height: 10,)
+                      ],
+                    );
+                  }   
+                }
+              ),
             )
           ],
+        )
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: ElevatedButton(
+        style: const ButtonStyle(
+          foregroundColor: MaterialStatePropertyAll<Color>(white),
+          backgroundColor: MaterialStatePropertyAll<Color>(navy),
         ),
+        child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
+        onPressed: () {
+          // Navigator.push(
+          //   context,
+          //   MaterialPageRoute(
+          //       builder: (context) => Diagnoses()),
+          // );
+        },
       )
     );
   }

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -1,32 +1,28 @@
-import 'dart:ffi';
-
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/userflow/chooseCategory.dart';
+import 'package:s_a_m_e/userflow/potentialDiagnosis.dart';
 
 class SelectSymptom extends StatefulWidget {
-  const SelectSymptom({Key? key, required this.category}) : super(key: key);
+  const SelectSymptom({super.key, required this.category});
 
   final Category category;
 
   @override
-  _SelectSymptomState createState() => _SelectSymptomState();
+  State<SelectSymptom> createState() => _SelectSymptomState();
 }
 
 class _SelectSymptomState extends State<SelectSymptom> {
 
-  List<bool> checked = [];
-  bool isChecked = false;
-  List<String> checkedItems = [];
   List<Map<String, dynamic>> checkedSymptoms = [];
 
   @override
   void initState() {
     super.initState();
     for (int i = 0; i < widget.category.symptoms.length; i++) {
-      checkedSymptoms.add({"name": widget.category.symptoms[i], "isChecked": false});
+      checkedSymptoms.add({"name": widget.category.symptoms[i], "isChecked": false}); // this doesn't work...
     }
+    print(checkedSymptoms);
   }
 
   @override
@@ -55,14 +51,16 @@ class _SelectSymptomState extends State<SelectSymptom> {
               height: 200,
               child: ListView.builder(
                 itemCount: widget.category.symptoms.length,
-                itemBuilder: (context, index) {
+                itemBuilder: (context, index)
+                {
                   if (widget.category.symptoms.isEmpty) {
                     return const Center(child: Text('No Symptoms Found'));
                   } else {
+                    print(checkedSymptoms);
                     return Column(
                       children: [
                         CheckboxListTile(
-                        value: isChecked,
+                        value: checkedSymptoms[index]["isChecked"],
                         title: Text(widget.category.symptoms[index]),
                         controlAffinity: ListTileControlAffinity.leading,
                         activeColor: navy,
@@ -71,18 +69,11 @@ class _SelectSymptomState extends State<SelectSymptom> {
                           borderRadius: BorderRadius.circular(15),
                           side: const BorderSide(color: teal)
                           ),
-                        onChanged: ((value) {
+                        onChanged: (value) {
                           setState(() {
-                            isChecked = value!;
-                            // if (value) {
-                            //   checkedItems.add(widget.category.symptoms[index]);
-                            // } else {
-                            //   if (checkedItems.contains(widget.category.symptoms[index])) {
-                            //     checkedItems.remove(widget.category.symptoms[index]);
-                            //   }
-                            // }
+                            checkedSymptoms[index]["isChecked"] = value!;
                           });
-                        }),
+                        },
                       ),
                       const SizedBox(height: 10,)
                       ],
@@ -102,11 +93,11 @@ class _SelectSymptomState extends State<SelectSymptom> {
         ),
         child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
         onPressed: () {
-          // Navigator.push(
-          //   context,
-          //   MaterialPageRoute(
-          //       builder: (context) => Diagnoses()),
-          // );
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms,)),
+          );
         },
       )
     );


### PR DESCRIPTION
Additions in this pull request

- displays the category previously selected
- displays all the symptoms from the previously selected category
- can select the symptoms using the `checkBoxTile`
- creates a List of Dictionaries with the name of the symptom & if that symptom is selected
- leads to a potential diagnosis page (rn just shows the list of dictionaries lol)