### PR TITLE
SCRUM-128: Display Potential Diagnosis Page

### DIFF
--- a/frontend/s_a_m_e/lib/admin/add_category.dart
+++ b/frontend/s_a_m_e/lib/admin/add_category.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/user/categorieslist.dart';
-import 'package:s_a_m_e/user/symptomlist.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class CategoryCreationPage extends StatefulWidget {
   const CategoryCreationPage({Key? key}) : super(key: key);

--- a/frontend/s_a_m_e/lib/admin/add_symptom.dart
+++ b/frontend/s_a_m_e/lib/admin/add_symptom.dart
@@ -3,7 +3,7 @@ import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/user/symptomlist.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class SymptomCreationPage extends StatefulWidget {
   const SymptomCreationPage({super.key});

--- a/frontend/s_a_m_e/lib/admin/admin_home.dart
+++ b/frontend/s_a_m_e/lib/admin/admin_home.dart
@@ -88,12 +88,12 @@ Widget build(BuildContext context) {
               ),
               child: const Text('Update Diagnoses List', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
               onPressed: () {
-                // Navigator.push(
-                //   context,
-                //   MaterialPageRoute(
-                //     builder: (context) => const EditDiagnosisPage(),
-                //   ),
-                // );
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const EditDiagnosisPage(),
+                  ),
+                );
               },
             ),
             //const SizedBox(height: 10),

--- a/frontend/s_a_m_e/lib/admin/admin_home.dart
+++ b/frontend/s_a_m_e/lib/admin/admin_home.dart
@@ -88,12 +88,12 @@ Widget build(BuildContext context) {
               ),
               child: const Text('Update Diagnoses List', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const EditDiagnosisPage(),
-                  ),
-                );
+                // Navigator.push(
+                //   context,
+                //   MaterialPageRoute(
+                //     builder: (context) => const EditDiagnosisPage(),
+                //   ),
+                // );
               },
             ),
             //const SizedBox(height: 10),

--- a/frontend/s_a_m_e/lib/admin/adminrequest.dart
+++ b/frontend/s_a_m_e/lib/admin/adminrequest.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class AdminRequestPage extends StatefulWidget {
   const AdminRequestPage({super.key});

--- a/frontend/s_a_m_e/lib/admin/delete_category.dart
+++ b/frontend/s_a_m_e/lib/admin/delete_category.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class CategoryDeletionPage extends StatefulWidget {
   const CategoryDeletionPage({super.key});

--- a/frontend/s_a_m_e/lib/admin/delete_symptom.dart
+++ b/frontend/s_a_m_e/lib/admin/delete_symptom.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class SymptomDeletionPage extends StatefulWidget {
   const SymptomDeletionPage({super.key});

--- a/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
+++ b/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart'; 
 import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class EditDiagnosisPage extends StatelessWidget {
   const EditDiagnosisPage({Key? key}) : super(key: key);
@@ -366,7 +366,7 @@ class _UpdateDiagnosisPageState extends State<UpdateDiagnosisPage> {
                   for (int i = 0; i < snapshot.data!.length; i++) {
                     diagnoses.add(snapshot.data![i].name);
                   }
-                  
+
                   print(diagnoses);
                   print(selectedDiagnosis);
                   return DropdownButton<String>(
@@ -531,7 +531,7 @@ class _DiagnosisDeletionPageState extends State<DiagnosisDeletionPage> {
                     diagnosis.add(snapshot.data![i].name);
                   }
                   // List<String>? diagnosis = snapshot.data;
-                  if (diagnosis != null && diagnosis.isNotEmpty) {
+                  if (diagnosis.isNotEmpty) {
                     return MultiSelectDialogField<String>(
                       backgroundColor: background,
                       cancelText: const Text(

--- a/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
+++ b/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
@@ -4,586 +4,586 @@ import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:s_a_m_e/account/profilepicture.dart';
 
-class EditDiagnosisPage extends StatelessWidget {
-  const EditDiagnosisPage({Key? key}) : super(key: key);
+// class EditDiagnosisPage extends StatelessWidget {
+//   const EditDiagnosisPage({Key? key}) : super(key: key);
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("S.A.M.E."),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const SizedBox(height: 20),
-            const Text(
-              'Update Diagnoses',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
-            ),
-            ElevatedButton(
-              style: const ButtonStyle(
-                  foregroundColor: MaterialStatePropertyAll<Color>(white),
-                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
-                ),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => DiagnosisCreationPage()),
-                );
-              },
-              child: const Text("Add Diagnosis"), 
-            ),
-            const SizedBox(height: 50),
-            ElevatedButton(
-              style: const ButtonStyle(
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         title: const Text("S.A.M.E."),
+//       ),
+//       body: Center(
+//         child: Column(
+//           mainAxisAlignment: MainAxisAlignment.center,
+//           children: [
+//             const SizedBox(height: 20),
+//             const Text(
+//               'Update Diagnoses',
+//               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
+//             ),
+//             ElevatedButton(
+//               style: const ButtonStyle(
+//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
+//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
+//                 ),
+//               onPressed: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(builder: (context) => DiagnosisCreationPage()),
+//                 );
+//               },
+//               child: const Text("Add Diagnosis"), 
+//             ),
+//             const SizedBox(height: 50),
+//             ElevatedButton(
+//               style: const ButtonStyle(
                   
-                  foregroundColor: MaterialStatePropertyAll<Color>(white),
-                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
-                ),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => UpdateDiagnosisPage()),
-                );
-              },
-              child: const Text("Update Diagnosis"),
-            ),
-            const SizedBox(height: 50),
-            ElevatedButton(
-              style: const ButtonStyle(
-                  foregroundColor: MaterialStatePropertyAll<Color>(white),
-                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
-                ),
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => DiagnosisDeletionPage()),
-                );
-              },
-              child: const Text("Delete Diagnosis"),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
+//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
+//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
+//                 ),
+//               onPressed: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(builder: (context) => UpdateDiagnosisPage()),
+//                 );
+//               },
+//               child: const Text("Update Diagnosis"),
+//             ),
+//             const SizedBox(height: 50),
+//             ElevatedButton(
+//               style: const ButtonStyle(
+//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
+//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
+//                 ),
+//               onPressed: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(builder: (context) => DiagnosisDeletionPage()),
+//                 );
+//               },
+//               child: const Text("Delete Diagnosis"),
+//             ),
+//           ],
+//         ),
+//       ),
+//     );
+//   }
+// }
 
 
-class DiagnosisCreationPage extends StatefulWidget {
-  const DiagnosisCreationPage({super.key});
+// class DiagnosisCreationPage extends StatefulWidget {
+//   const DiagnosisCreationPage({super.key});
 
-  @override
-  _DiagnosisCreationPageState createState() => _DiagnosisCreationPageState();
-}
+//   @override
+//   _DiagnosisCreationPageState createState() => _DiagnosisCreationPageState();
+// }
 
-class _DiagnosisCreationPageState extends State<DiagnosisCreationPage> {
-  //final _apiService = ApiService();
-  final _diagnosisNameController = TextEditingController();
-  final _diagnosisDefinitionController = TextEditingController();
-  final FirebaseService _firebaseService = FirebaseService();
-  List<String> _selectedSymptoms = [];
+// class _DiagnosisCreationPageState extends State<DiagnosisCreationPage> {
+//   //final _apiService = ApiService();
+//   final _diagnosisNameController = TextEditingController();
+//   final _diagnosisDefinitionController = TextEditingController();
+//   final FirebaseService _firebaseService = FirebaseService();
+//   List<String> _selectedSymptoms = [];
 
-  @override
-  void dispose() {
-    _diagnosisNameController.dispose();
-    _diagnosisDefinitionController.dispose();
-    super.dispose();
-  }
+//   @override
+//   void dispose() {
+//     _diagnosisNameController.dispose();
+//     _diagnosisDefinitionController.dispose();
+//     super.dispose();
+//   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('S.A.M.E'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(15.0),
-        child: Column(
-          children: [
-            const SizedBox(height: 20),
-            const Text('Add Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0)),
-            const SizedBox(height: 40),
-            TextField(
-              controller: _diagnosisNameController,
-              decoration: const InputDecoration(
-                contentPadding: EdgeInsets.all(20.0),
-                labelText: 'Diagnosis Name',
-                labelStyle: TextStyle(color: navy),
-                filled: true,
-                fillColor: boxinsides,
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-              ),
-            ),
-            const SizedBox(height: 40),
-            TextField(
-              controller: _diagnosisDefinitionController,
-              decoration: const InputDecoration(
-                contentPadding: EdgeInsets.all(20.0),
-                labelText: 'Diagnosis Definition',
-                labelStyle: TextStyle(color: navy),
-                filled: true,
-                fillColor: boxinsides,
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-              ),
-            ),
-            const SizedBox(height: 30),
-            FutureBuilder<List<String>>(
-              future: _firebaseService.getAllSymptoms(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const CircularProgressIndicator();
-                } else if (snapshot.hasError) {
-                  return Text('Error: ${snapshot.error}');
-                } else {
-                  List<String>? symptoms = snapshot.data;
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         title: const Text('S.A.M.E'),
+//       ),
+//       body: Padding(
+//         padding: const EdgeInsets.all(15.0),
+//         child: Column(
+//           children: [
+//             const SizedBox(height: 20),
+//             const Text('Add Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0)),
+//             const SizedBox(height: 40),
+//             TextField(
+//               controller: _diagnosisNameController,
+//               decoration: const InputDecoration(
+//                 contentPadding: EdgeInsets.all(20.0),
+//                 labelText: 'Diagnosis Name',
+//                 labelStyle: TextStyle(color: navy),
+//                 filled: true,
+//                 fillColor: boxinsides,
+//                 focusedBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//                 enabledBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//               ),
+//             ),
+//             const SizedBox(height: 40),
+//             TextField(
+//               controller: _diagnosisDefinitionController,
+//               decoration: const InputDecoration(
+//                 contentPadding: EdgeInsets.all(20.0),
+//                 labelText: 'Diagnosis Definition',
+//                 labelStyle: TextStyle(color: navy),
+//                 filled: true,
+//                 fillColor: boxinsides,
+//                 focusedBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//                 enabledBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//               ),
+//             ),
+//             const SizedBox(height: 30),
+//             FutureBuilder<List<String>>(
+//               future: _firebaseService.getAllSymptoms(),
+//               builder: (context, snapshot) {
+//                 if (snapshot.connectionState == ConnectionState.waiting) {
+//                   return const CircularProgressIndicator();
+//                 } else if (snapshot.hasError) {
+//                   return Text('Error: ${snapshot.error}');
+//                 } else {
+//                   List<String>? symptoms = snapshot.data;
 
-                  if (symptoms != null && symptoms.isNotEmpty) {
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const SizedBox(height: 20),
-                        const Text('Select Symptoms:'),
-                        SizedBox(
-                          height: 200,
-                          child: ListView.builder(
-                            itemCount: symptoms.length,
-                            itemBuilder: (context, index) {
-                              final symptom = symptoms[index];
-                              return CheckboxListTile(
-                                title: Text(symptom),
-                                value: _selectedSymptoms.contains(symptom),
-                                onChanged: (value) {
-                                  setState(() {
-                                    if (value != null && value) {
-                                      _selectedSymptoms.add(symptom);
-                                    } else {
-                                      _selectedSymptoms.remove(symptom);
-                                    }
-                                  });
-                                },
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    );
-                  } else {
-                    return const Text('No symptoms available');
-                  }
-                }
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              style: const ButtonStyle(
-                  foregroundColor: MaterialStatePropertyAll<Color>(white),
-                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
-                ),
-              onPressed: () async {
-                if ((_diagnosisNameController.text.isNotEmpty &&
-                    _diagnosisDefinitionController.text.isNotEmpty &&
-                    _selectedSymptoms.isNotEmpty) && await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
-                  final response = await _firebaseService.addDiagnosis(
-                    _diagnosisNameController.text,
-                    _diagnosisDefinitionController.text,
-                    _selectedSymptoms,
-                  );
-                  if (response == 200) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Diagnosis added successfully')),
-                    );
-                    _diagnosisNameController.clear();
-                    _diagnosisDefinitionController.clear();
+//                   if (symptoms != null && symptoms.isNotEmpty) {
+//                     return Column(
+//                       crossAxisAlignment: CrossAxisAlignment.start,
+//                       children: [
+//                         const SizedBox(height: 20),
+//                         const Text('Select Symptoms:'),
+//                         SizedBox(
+//                           height: 200,
+//                           child: ListView.builder(
+//                             itemCount: symptoms.length,
+//                             itemBuilder: (context, index) {
+//                               final symptom = symptoms[index];
+//                               return CheckboxListTile(
+//                                 title: Text(symptom),
+//                                 value: _selectedSymptoms.contains(symptom),
+//                                 onChanged: (value) {
+//                                   setState(() {
+//                                     if (value != null && value) {
+//                                       _selectedSymptoms.add(symptom);
+//                                     } else {
+//                                       _selectedSymptoms.remove(symptom);
+//                                     }
+//                                   });
+//                                 },
+//                               );
+//                             },
+//                           ),
+//                         ),
+//                       ],
+//                     );
+//                   } else {
+//                     return const Text('No symptoms available');
+//                   }
+//                 }
+//               },
+//             ),
+//             const SizedBox(height: 20),
+//             ElevatedButton(
+//               style: const ButtonStyle(
+//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
+//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
+//                 ),
+//               onPressed: () async {
+//                 if ((_diagnosisNameController.text.isNotEmpty &&
+//                     _diagnosisDefinitionController.text.isNotEmpty &&
+//                     _selectedSymptoms.isNotEmpty) && await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
+//                   final response = await _firebaseService.addDiagnosis(
+//                     _diagnosisNameController.text,
+//                     _diagnosisDefinitionController.text,
+//                     _selectedSymptoms,
+//                   );
+//                   if (response == 200) {
+//                     ScaffoldMessenger.of(context).showSnackBar(
+//                       const SnackBar(content: Text('Diagnosis added successfully')),
+//                     );
+//                     _diagnosisNameController.clear();
+//                     _diagnosisDefinitionController.clear();
 
 
 
-                  } else {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Failed to add diagnosis')),
-                    );
-                  }
-                } else if (!await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Diagnosis already in database')),
-                  );
+//                   } else {
+//                     ScaffoldMessenger.of(context).showSnackBar(
+//                       const SnackBar(content: Text('Failed to add diagnosis')),
+//                     );
+//                   }
+//                 } else if (!await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
+//                   ScaffoldMessenger.of(context).showSnackBar(
+//                     const SnackBar(content: Text('Diagnosis already in database')),
+//                   );
                   
 
-                }
-                else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Please fill all the fields')),
-                  );
-                }
-              },
-              child: const Text('Create Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0)),
-            ),
-            const SizedBox(height: 20),
-          ],
-        ),
-      ),
-    );
-  }
-}
+//                 }
+//                 else {
+//                   ScaffoldMessenger.of(context).showSnackBar(
+//                     const SnackBar(content: Text('Please fill all the fields')),
+//                   );
+//                 }
+//               },
+//               child: const Text('Create Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0)),
+//             ),
+//             const SizedBox(height: 20),
+//           ],
+//         ),
+//       ),
+//     );
+//   }
+// }
 
-//UPDATE
+// //UPDATE
 
-class UpdateDiagnosisPage extends StatefulWidget {
-  @override
-  _UpdateDiagnosisPageState createState() => _UpdateDiagnosisPageState();
-}
+// class UpdateDiagnosisPage extends StatefulWidget {
+//   @override
+//   _UpdateDiagnosisPageState createState() => _UpdateDiagnosisPageState();
+// }
 
-class _UpdateDiagnosisPageState extends State<UpdateDiagnosisPage> {
-  final _diagnosisUpdateDefinitionController = TextEditingController();
-  String selectedDiagnosis = '';
-  String definitionUdate = '';
-  List<String> symptomsToAdd = [];
-  List<String> symptomsToDelete = [];
-  Map<String, bool> symptomCheckedState = {};
+// class _UpdateDiagnosisPageState extends State<UpdateDiagnosisPage> {
+//   final _diagnosisUpdateDefinitionController = TextEditingController();
+//   String selectedDiagnosis = '';
+//   String definitionUdate = '';
+//   List<String> symptomsToAdd = [];
+//   List<String> symptomsToDelete = [];
+//   Map<String, bool> symptomCheckedState = {};
 
-  @override
-  void initState() {
-    //_diagnosisUpdateDefinitionController.dispose();
-    super.initState();
-    fetchDiagnoses();
-  }
+//   @override
+//   void initState() {
+//     //_diagnosisUpdateDefinitionController.dispose();
+//     super.initState();
+//     fetchDiagnoses();
+//   }
 
-   @override
-  void dispose() {
-    _diagnosisUpdateDefinitionController.dispose();
-    super.dispose();
-  }
+//    @override
+//   void dispose() {
+//     _diagnosisUpdateDefinitionController.dispose();
+//     super.dispose();
+//   }
 
-  Future<void> fetchDiagnoses() async {
-    List<String> diagnoses = await FirebaseService().getAllDiagnosis();
-    print(diagnoses);
-    setState(() {
-      selectedDiagnosis = diagnoses.isNotEmpty ? diagnoses[0] : '';
-      print("hello");
-      print(selectedDiagnosis);
-      print("hello");
-    });
-    fetchSymptoms(selectedDiagnosis);
-  }
+//   Future<void> fetchDiagnoses() async {
+//     List<String> diagnoses = await FirebaseService().getAllDiagnosis();
+//     print(diagnoses);
+//     setState(() {
+//       selectedDiagnosis = diagnoses.isNotEmpty ? diagnoses[0] : '';
+//       print("hello");
+//       print(selectedDiagnosis);
+//       print("hello");
+//     });
+//     fetchSymptoms(selectedDiagnosis);
+//   }
 
-  Future<void> fetchSymptoms(String diagnosisName) async {
-    List<String> allSymptoms =
-        await FirebaseService().getAllSymptoms();
+//   Future<void> fetchSymptoms(String diagnosisName) async {
+//     List<String> allSymptoms =
+//         await FirebaseService().getAllSymptoms();
 
-    List<String> currentSymptoms =
-        await FirebaseService().getSymptomsForDiagnosis(diagnosisName);
+//     List<String> currentSymptoms =
+//         await FirebaseService().getSymptomsForDiagnosis(diagnosisName);
 
-    List<String> symptomsForAddition = [];
+//     List<String> symptomsForAddition = [];
 
-    for (String symptom in allSymptoms) {
-      if (!currentSymptoms.contains(symptom)) {
-        symptomsForAddition.add(symptom);
-      }
-    }
+//     for (String symptom in allSymptoms) {
+//       if (!currentSymptoms.contains(symptom)) {
+//         symptomsForAddition.add(symptom);
+//       }
+//     }
 
-    setState(() {
-      symptomsToDelete = currentSymptoms;
-      symptomsToAdd = symptomsForAddition;
-      symptomCheckedState = Map.fromIterable(allSymptoms,
-          key: (symptom) => symptom, value: (_) => false);
-    });
-  }
+//     setState(() {
+//       symptomsToDelete = currentSymptoms;
+//       symptomsToAdd = symptomsForAddition;
+//       symptomCheckedState = Map.fromIterable(allSymptoms,
+//           key: (symptom) => symptom, value: (_) => false);
+//     });
+//   }
 
-  Future<void> updateSymptoms() async {
-    List<String> symptomsSelectedAdd = [];
-    List<String> symptomsSelectedDel = [];
+//   Future<void> updateSymptoms() async {
+//     List<String> symptomsSelectedAdd = [];
+//     List<String> symptomsSelectedDel = [];
 
-    symptomCheckedState.forEach((symptom, isChecked) {
-      if (isChecked && symptomsToAdd.contains(symptom)) {
-        symptomsSelectedAdd.add(symptom);
-      } else if (isChecked && symptomsToDelete.contains(symptom)) {
-        symptomsSelectedDel.add(symptom);
-      }
-    });
+//     symptomCheckedState.forEach((symptom, isChecked) {
+//       if (isChecked && symptomsToAdd.contains(symptom)) {
+//         symptomsSelectedAdd.add(symptom);
+//       } else if (isChecked && symptomsToDelete.contains(symptom)) {
+//         symptomsSelectedDel.add(symptom);
+//       }
+//     });
 
-    for (String symptom in symptomsSelectedAdd) {
-      await FirebaseService().addSymptomToDiagnosis(
-        symptom,
-        selectedDiagnosis,
-      );
-    }
+//     for (String symptom in symptomsSelectedAdd) {
+//       await FirebaseService().addSymptomToDiagnosis(
+//         symptom,
+//         selectedDiagnosis,
+//       );
+//     }
 
-    for (String symptom in symptomsSelectedDel) {
-      await FirebaseService().removeSymptomFromDiagnosis(
-        symptom,
-        selectedDiagnosis,
-      );
-    }
+//     for (String symptom in symptomsSelectedDel) {
+//       await FirebaseService().removeSymptomFromDiagnosis(
+//         symptom,
+//         selectedDiagnosis,
+//       );
+//     }
 
-    setState(() {
-      symptomsSelectedAdd.clear();
-      symptomsSelectedDel.clear();
-    });
+//     setState(() {
+//       symptomsSelectedAdd.clear();
+//       symptomsSelectedDel.clear();
+//     });
 
-    fetchSymptoms(selectedDiagnosis);
-  }
+//     fetchSymptoms(selectedDiagnosis);
+//   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'Update Diagnosis',
-          style: TextStyle(fontSize: 40),
-        ),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            FutureBuilder<List<String>>(
-              future: FirebaseService().getAllDiagnosis(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return CircularProgressIndicator();
-                } else if (snapshot.hasError) {
-                  return Text('Error: ${snapshot.error}');
-                } else {
-                  List<String> diagnoses = snapshot.data ?? [];
-                  print(diagnoses);
-                  print(selectedDiagnosis);
-                  return DropdownButton<String>(
-                    value: selectedDiagnosis,
-                    items: diagnoses.map((String diagnosis) {
-                      return DropdownMenuItem<String>(
-                        value: diagnosis,
-                        child: Text(diagnosis),
-                      );
-                    }).toList(),
-                    onChanged: (String? value) {
-                      if (value != null) {
-                        setState(() {
-                          selectedDiagnosis = value;
-                        });
-                        fetchSymptoms(selectedDiagnosis);
-                      }
-                    },
-                  );
-                }
-              },
-            ),
-            SizedBox(height: 10),
-            TextField(
-              controller: _diagnosisUpdateDefinitionController,
-              decoration: const InputDecoration(
-                contentPadding: EdgeInsets.all(20.0),
-                labelText: 'Update Definition',
-                labelStyle: TextStyle(color: navy),
-                filled: true,
-                fillColor: boxinsides,
-                focusedBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderSide: BorderSide(color: boxinsides),
-                  borderRadius: BorderRadius.all(Radius.circular(40.0))
-                ),
-              ),
-            ),
-            // Text(
-            //   'Update Definition:',
-            //   style: TextStyle(fontWeight: FontWeight.bold),
-            // ),
-            SizedBox(height: 10),
-            Text(
-              'Add Symptoms:',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            Flexible(
-              child: ListView.builder(
-                itemCount: symptomsToAdd.length,
-                itemBuilder: (context, index) {
-                  final symptom = symptomsToAdd[index];
-                  return ListTile(
-                    title: Text(symptom),
-                    trailing: Checkbox(
-                      value: symptomCheckedState[symptom] ?? false,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          symptomCheckedState[symptom] = value ?? false;
-                        });
-                      },
-                    ),
-                  );
-                },
-              ),
-            ),
-            SizedBox(height: 10),
-            Text(
-              'Remove Symptoms:',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
-            Flexible(
-              child: ListView.builder(
-                itemCount: symptomsToDelete.length,
-                itemBuilder: (context, index) {
-                  final symptom = symptomsToDelete[index];
-                  return ListTile(
-                    title: Text(symptom),
-                    trailing: Checkbox(
-                      value: symptomCheckedState[symptom] ?? false,
-                      onChanged: (bool? value) {
-                        setState(() {
-                          symptomCheckedState[symptom] = value ?? false;
-                        });
-                      },
-                    ),
-                  );
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          if (_diagnosisUpdateDefinitionController.text.isNotEmpty) {
-            final response = await FirebaseService().updateDiagnosisDef(selectedDiagnosis, _diagnosisUpdateDefinitionController.text);
-            if (response == 200) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Diagnosis added successfully')),
-              );
-            } else {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Failed to add diagnosis')),
-              );
-            }
-          } 
-          updateSymptoms();
-        },
-        // onPressed: () {
-        //   updateCategories();
-        // },
-        child: Icon(Icons.check),
-      ),
-    );
-  }
-}
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         title: Text(
+//           'Update Diagnosis',
+//           style: TextStyle(fontSize: 40),
+//         ),
+//       ),
+//       body: Padding(
+//         padding: const EdgeInsets.all(16.0),
+//         child: Column(
+//           crossAxisAlignment: CrossAxisAlignment.start,
+//           children: [
+//             FutureBuilder<List<String>>(
+//               future: FirebaseService().getAllDiagnosis(),
+//               builder: (context, snapshot) {
+//                 if (snapshot.connectionState == ConnectionState.waiting) {
+//                   return CircularProgressIndicator();
+//                 } else if (snapshot.hasError) {
+//                   return Text('Error: ${snapshot.error}');
+//                 } else {
+//                   List<String> diagnoses = snapshot.data ?? [];
+//                   print(diagnoses);
+//                   print(selectedDiagnosis);
+//                   return DropdownButton<String>(
+//                     value: selectedDiagnosis,
+//                     items: diagnoses.map((String diagnosis) {
+//                       return DropdownMenuItem<String>(
+//                         value: diagnosis,
+//                         child: Text(diagnosis),
+//                       );
+//                     }).toList(),
+//                     onChanged: (String? value) {
+//                       if (value != null) {
+//                         setState(() {
+//                           selectedDiagnosis = value;
+//                         });
+//                         fetchSymptoms(selectedDiagnosis);
+//                       }
+//                     },
+//                   );
+//                 }
+//               },
+//             ),
+//             SizedBox(height: 10),
+//             TextField(
+//               controller: _diagnosisUpdateDefinitionController,
+//               decoration: const InputDecoration(
+//                 contentPadding: EdgeInsets.all(20.0),
+//                 labelText: 'Update Definition',
+//                 labelStyle: TextStyle(color: navy),
+//                 filled: true,
+//                 fillColor: boxinsides,
+//                 focusedBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//                 enabledBorder: OutlineInputBorder(
+//                   borderSide: BorderSide(color: boxinsides),
+//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
+//                 ),
+//               ),
+//             ),
+//             // Text(
+//             //   'Update Definition:',
+//             //   style: TextStyle(fontWeight: FontWeight.bold),
+//             // ),
+//             SizedBox(height: 10),
+//             Text(
+//               'Add Symptoms:',
+//               style: TextStyle(fontWeight: FontWeight.bold),
+//             ),
+//             Flexible(
+//               child: ListView.builder(
+//                 itemCount: symptomsToAdd.length,
+//                 itemBuilder: (context, index) {
+//                   final symptom = symptomsToAdd[index];
+//                   return ListTile(
+//                     title: Text(symptom),
+//                     trailing: Checkbox(
+//                       value: symptomCheckedState[symptom] ?? false,
+//                       onChanged: (bool? value) {
+//                         setState(() {
+//                           symptomCheckedState[symptom] = value ?? false;
+//                         });
+//                       },
+//                     ),
+//                   );
+//                 },
+//               ),
+//             ),
+//             SizedBox(height: 10),
+//             Text(
+//               'Remove Symptoms:',
+//               style: TextStyle(fontWeight: FontWeight.bold),
+//             ),
+//             Flexible(
+//               child: ListView.builder(
+//                 itemCount: symptomsToDelete.length,
+//                 itemBuilder: (context, index) {
+//                   final symptom = symptomsToDelete[index];
+//                   return ListTile(
+//                     title: Text(symptom),
+//                     trailing: Checkbox(
+//                       value: symptomCheckedState[symptom] ?? false,
+//                       onChanged: (bool? value) {
+//                         setState(() {
+//                           symptomCheckedState[symptom] = value ?? false;
+//                         });
+//                       },
+//                     ),
+//                   );
+//                 },
+//               ),
+//             ),
+//           ],
+//         ),
+//       ),
+//       floatingActionButton: FloatingActionButton(
+//         onPressed: () async {
+//           if (_diagnosisUpdateDefinitionController.text.isNotEmpty) {
+//             final response = await FirebaseService().updateDiagnosisDef(selectedDiagnosis, _diagnosisUpdateDefinitionController.text);
+//             if (response == 200) {
+//               ScaffoldMessenger.of(context).showSnackBar(
+//                 const SnackBar(content: Text('Diagnosis added successfully')),
+//               );
+//             } else {
+//               ScaffoldMessenger.of(context).showSnackBar(
+//                 const SnackBar(content: Text('Failed to add diagnosis')),
+//               );
+//             }
+//           } 
+//           updateSymptoms();
+//         },
+//         // onPressed: () {
+//         //   updateCategories();
+//         // },
+//         child: Icon(Icons.check),
+//       ),
+//     );
+//   }
+// }
 
 
 
-class DiagnosisDeletionPage extends StatefulWidget {
-  const DiagnosisDeletionPage({super.key});
+// class DiagnosisDeletionPage extends StatefulWidget {
+//   const DiagnosisDeletionPage({super.key});
 
-  @override
-  _DiagnosisDeletionPageState createState() => _DiagnosisDeletionPageState();
-}
+//   @override
+//   _DiagnosisDeletionPageState createState() => _DiagnosisDeletionPageState();
+// }
 
-class _DiagnosisDeletionPageState extends State<DiagnosisDeletionPage> {
-  List<String> _selectedDiagnosis= [];
-  final FirebaseService _firebaseService = FirebaseService();
+// class _DiagnosisDeletionPageState extends State<DiagnosisDeletionPage> {
+//   List<String> _selectedDiagnosis= [];
+//   final FirebaseService _firebaseService = FirebaseService();
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('S.A.M.E'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(15.0),
-        child: Column(
-          children: [
-            const SizedBox(height: 20),
-            const Text(
-              'Delete Symptom',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
-            ),
-            const SizedBox(height: 40),
-            FutureBuilder<List<String>>(
-              //RAMYA MAKE FIREBASE METHOD
-              future: _firebaseService.getAllDiagnosis(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const CircularProgressIndicator();
-                } else if (snapshot.hasError) {
-                  return Text('Error: ${snapshot.error}');
-                } else {
-                  List<String>? diagnosis = snapshot.data;
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         title: const Text('S.A.M.E'),
+//       ),
+//       body: Padding(
+//         padding: const EdgeInsets.all(15.0),
+//         child: Column(
+//           children: [
+//             const SizedBox(height: 20),
+//             const Text(
+//               'Delete Symptom',
+//               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
+//             ),
+//             const SizedBox(height: 40),
+//             FutureBuilder<List<String>>(
+//               //RAMYA MAKE FIREBASE METHOD
+//               future: _firebaseService.getAllDiagnosis(),
+//               builder: (context, snapshot) {
+//                 if (snapshot.connectionState == ConnectionState.waiting) {
+//                   return const CircularProgressIndicator();
+//                 } else if (snapshot.hasError) {
+//                   return Text('Error: ${snapshot.error}');
+//                 } else {
+//                   List<String>? diagnosis = snapshot.data;
 
-                  if (diagnosis != null && diagnosis.isNotEmpty) {
-                    return MultiSelectDialogField<String>(
-                      backgroundColor: background,
-                      cancelText: const Text(
-                        'CANCEL',
-                        style: TextStyle(fontWeight: FontWeight.bold, color: navy),
-                      ),
-                      confirmText: const Text(
-                        'SELECT',
-                        style: TextStyle(fontWeight: FontWeight.bold, color: navy),
-                      ),
-                      unselectedColor: navy,
-                      selectedColor: navy,
-                      items: diagnosis
-                          .map((diagnosis) => MultiSelectItem<String>(diagnosis, diagnosis))
-                          .toList(),
-                      title: const Text("Diagnosis"),
-                      onConfirm: (values) {
-                        _selectedDiagnosis = values;
-                      },
-                    );
-                  } else {
-                    return const Text('No symptoms available');
-                  }
-                }
-              },
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              style: const ButtonStyle(
-                foregroundColor: MaterialStatePropertyAll<Color>(white),
-                backgroundColor: MaterialStatePropertyAll<Color>(navy),
-              ),
-              onPressed: () async {
-                if (_selectedDiagnosis.isNotEmpty) {
-                  for (String diagnosis in _selectedDiagnosis) {
-                    //RAMYA MAKE FIREBASE METHOD
-                    await _firebaseService.deleteDiagnosis(diagnosis);
-                  }
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Diagnosis deleted successfully'),
-                    ),
-                  );
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Please select diagnosis to delete'),
-                    ),
-                  );
-                }
-              },
-              child: const Text(
-                'Delete Symptoms',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0),
-              ),
-            ),
-            const SizedBox(height: 20),
-          ],
-        ),
-      ),
-    );
-  }
-}
+//                   if (diagnosis != null && diagnosis.isNotEmpty) {
+//                     return MultiSelectDialogField<String>(
+//                       backgroundColor: background,
+//                       cancelText: const Text(
+//                         'CANCEL',
+//                         style: TextStyle(fontWeight: FontWeight.bold, color: navy),
+//                       ),
+//                       confirmText: const Text(
+//                         'SELECT',
+//                         style: TextStyle(fontWeight: FontWeight.bold, color: navy),
+//                       ),
+//                       unselectedColor: navy,
+//                       selectedColor: navy,
+//                       items: diagnosis
+//                           .map((diagnosis) => MultiSelectItem<String>(diagnosis, diagnosis))
+//                           .toList(),
+//                       title: const Text("Diagnosis"),
+//                       onConfirm: (values) {
+//                         _selectedDiagnosis = values;
+//                       },
+//                     );
+//                   } else {
+//                     return const Text('No symptoms available');
+//                   }
+//                 }
+//               },
+//             ),
+//             const SizedBox(height: 20),
+//             ElevatedButton(
+//               style: const ButtonStyle(
+//                 foregroundColor: MaterialStatePropertyAll<Color>(white),
+//                 backgroundColor: MaterialStatePropertyAll<Color>(navy),
+//               ),
+//               onPressed: () async {
+//                 if (_selectedDiagnosis.isNotEmpty) {
+//                   for (String diagnosis in _selectedDiagnosis) {
+//                     //RAMYA MAKE FIREBASE METHOD
+//                     await _firebaseService.deleteDiagnosis(diagnosis);
+//                   }
+//                   ScaffoldMessenger.of(context).showSnackBar(
+//                     const SnackBar(
+//                       content: Text('Diagnosis deleted successfully'),
+//                     ),
+//                   );
+//                 } else {
+//                   ScaffoldMessenger.of(context).showSnackBar(
+//                     const SnackBar(
+//                       content: Text('Please select diagnosis to delete'),
+//                     ),
+//                   );
+//                 }
+//               },
+//               child: const Text(
+//                 'Delete Symptoms',
+//                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0),
+//               ),
+//             ),
+//             const SizedBox(height: 20),
+//           ],
+//         ),
+//       ),
+//     );
+//   }
+// }

--- a/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
+++ b/frontend/s_a_m_e/lib/admin/editDiagnoses.dart
@@ -4,586 +4,594 @@ import 'package:multi_select_flutter/multi_select_flutter.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:s_a_m_e/account/profilepicture.dart';
 
-// class EditDiagnosisPage extends StatelessWidget {
-//   const EditDiagnosisPage({Key? key}) : super(key: key);
+class EditDiagnosisPage extends StatelessWidget {
+  const EditDiagnosisPage({Key? key}) : super(key: key);
 
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(
-//         title: const Text("S.A.M.E."),
-//       ),
-//       body: Center(
-//         child: Column(
-//           mainAxisAlignment: MainAxisAlignment.center,
-//           children: [
-//             const SizedBox(height: 20),
-//             const Text(
-//               'Update Diagnoses',
-//               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
-//             ),
-//             ElevatedButton(
-//               style: const ButtonStyle(
-//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
-//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
-//                 ),
-//               onPressed: () {
-//                 Navigator.push(
-//                   context,
-//                   MaterialPageRoute(builder: (context) => DiagnosisCreationPage()),
-//                 );
-//               },
-//               child: const Text("Add Diagnosis"), 
-//             ),
-//             const SizedBox(height: 50),
-//             ElevatedButton(
-//               style: const ButtonStyle(
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("S.A.M.E."),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(height: 20),
+            const Text(
+              'Update Diagnoses',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
+            ),
+            ElevatedButton(
+              style: const ButtonStyle(
+                  foregroundColor: MaterialStatePropertyAll<Color>(white),
+                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
+                ),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => DiagnosisCreationPage()),
+                );
+              },
+              child: const Text("Add Diagnosis"), 
+            ),
+            const SizedBox(height: 50),
+            ElevatedButton(
+              style: const ButtonStyle(
                   
-//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
-//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
-//                 ),
-//               onPressed: () {
-//                 Navigator.push(
-//                   context,
-//                   MaterialPageRoute(builder: (context) => UpdateDiagnosisPage()),
-//                 );
-//               },
-//               child: const Text("Update Diagnosis"),
-//             ),
-//             const SizedBox(height: 50),
-//             ElevatedButton(
-//               style: const ButtonStyle(
-//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
-//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
-//                 ),
-//               onPressed: () {
-//                 Navigator.push(
-//                   context,
-//                   MaterialPageRoute(builder: (context) => DiagnosisDeletionPage()),
-//                 );
-//               },
-//               child: const Text("Delete Diagnosis"),
-//             ),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }
+                  foregroundColor: MaterialStatePropertyAll<Color>(white),
+                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
+                ),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => UpdateDiagnosisPage()),
+                );
+              },
+              child: const Text("Update Diagnosis"),
+            ),
+            const SizedBox(height: 50),
+            ElevatedButton(
+              style: const ButtonStyle(
+                  foregroundColor: MaterialStatePropertyAll<Color>(white),
+                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
+                ),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => DiagnosisDeletionPage()),
+                );
+              },
+              child: const Text("Delete Diagnosis"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
 
-// class DiagnosisCreationPage extends StatefulWidget {
-//   const DiagnosisCreationPage({super.key});
+class DiagnosisCreationPage extends StatefulWidget {
+  const DiagnosisCreationPage({super.key});
 
-//   @override
-//   _DiagnosisCreationPageState createState() => _DiagnosisCreationPageState();
-// }
+  @override
+  _DiagnosisCreationPageState createState() => _DiagnosisCreationPageState();
+}
 
-// class _DiagnosisCreationPageState extends State<DiagnosisCreationPage> {
-//   //final _apiService = ApiService();
-//   final _diagnosisNameController = TextEditingController();
-//   final _diagnosisDefinitionController = TextEditingController();
-//   final FirebaseService _firebaseService = FirebaseService();
-//   List<String> _selectedSymptoms = [];
+class _DiagnosisCreationPageState extends State<DiagnosisCreationPage> {
+  //final _apiService = ApiService();
+  final _diagnosisNameController = TextEditingController();
+  final _diagnosisDefinitionController = TextEditingController();
+  final FirebaseService _firebaseService = FirebaseService();
+  List<String> _selectedSymptoms = [];
 
-//   @override
-//   void dispose() {
-//     _diagnosisNameController.dispose();
-//     _diagnosisDefinitionController.dispose();
-//     super.dispose();
-//   }
+  @override
+  void dispose() {
+    _diagnosisNameController.dispose();
+    _diagnosisDefinitionController.dispose();
+    super.dispose();
+  }
 
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(
-//         title: const Text('S.A.M.E'),
-//       ),
-//       body: Padding(
-//         padding: const EdgeInsets.all(15.0),
-//         child: Column(
-//           children: [
-//             const SizedBox(height: 20),
-//             const Text('Add Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0)),
-//             const SizedBox(height: 40),
-//             TextField(
-//               controller: _diagnosisNameController,
-//               decoration: const InputDecoration(
-//                 contentPadding: EdgeInsets.all(20.0),
-//                 labelText: 'Diagnosis Name',
-//                 labelStyle: TextStyle(color: navy),
-//                 filled: true,
-//                 fillColor: boxinsides,
-//                 focusedBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//                 enabledBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//               ),
-//             ),
-//             const SizedBox(height: 40),
-//             TextField(
-//               controller: _diagnosisDefinitionController,
-//               decoration: const InputDecoration(
-//                 contentPadding: EdgeInsets.all(20.0),
-//                 labelText: 'Diagnosis Definition',
-//                 labelStyle: TextStyle(color: navy),
-//                 filled: true,
-//                 fillColor: boxinsides,
-//                 focusedBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//                 enabledBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//               ),
-//             ),
-//             const SizedBox(height: 30),
-//             FutureBuilder<List<String>>(
-//               future: _firebaseService.getAllSymptoms(),
-//               builder: (context, snapshot) {
-//                 if (snapshot.connectionState == ConnectionState.waiting) {
-//                   return const CircularProgressIndicator();
-//                 } else if (snapshot.hasError) {
-//                   return Text('Error: ${snapshot.error}');
-//                 } else {
-//                   List<String>? symptoms = snapshot.data;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('S.A.M.E'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(15.0),
+        child: Column(
+          children: [
+            const SizedBox(height: 20),
+            const Text('Add Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0)),
+            const SizedBox(height: 40),
+            TextField(
+              controller: _diagnosisNameController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(20.0),
+                labelText: 'Diagnosis Name',
+                labelStyle: TextStyle(color: navy),
+                filled: true,
+                fillColor: boxinsides,
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+            TextField(
+              controller: _diagnosisDefinitionController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(20.0),
+                labelText: 'Diagnosis Definition',
+                labelStyle: TextStyle(color: navy),
+                filled: true,
+                fillColor: boxinsides,
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+              ),
+            ),
+            const SizedBox(height: 30),
+            FutureBuilder<List<String>>(
+              future: _firebaseService.getAllSymptoms(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  List<String>? symptoms = snapshot.data;
 
-//                   if (symptoms != null && symptoms.isNotEmpty) {
-//                     return Column(
-//                       crossAxisAlignment: CrossAxisAlignment.start,
-//                       children: [
-//                         const SizedBox(height: 20),
-//                         const Text('Select Symptoms:'),
-//                         SizedBox(
-//                           height: 200,
-//                           child: ListView.builder(
-//                             itemCount: symptoms.length,
-//                             itemBuilder: (context, index) {
-//                               final symptom = symptoms[index];
-//                               return CheckboxListTile(
-//                                 title: Text(symptom),
-//                                 value: _selectedSymptoms.contains(symptom),
-//                                 onChanged: (value) {
-//                                   setState(() {
-//                                     if (value != null && value) {
-//                                       _selectedSymptoms.add(symptom);
-//                                     } else {
-//                                       _selectedSymptoms.remove(symptom);
-//                                     }
-//                                   });
-//                                 },
-//                               );
-//                             },
-//                           ),
-//                         ),
-//                       ],
-//                     );
-//                   } else {
-//                     return const Text('No symptoms available');
-//                   }
-//                 }
-//               },
-//             ),
-//             const SizedBox(height: 20),
-//             ElevatedButton(
-//               style: const ButtonStyle(
-//                   foregroundColor: MaterialStatePropertyAll<Color>(white),
-//                   backgroundColor: MaterialStatePropertyAll<Color>(navy),
-//                 ),
-//               onPressed: () async {
-//                 if ((_diagnosisNameController.text.isNotEmpty &&
-//                     _diagnosisDefinitionController.text.isNotEmpty &&
-//                     _selectedSymptoms.isNotEmpty) && await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
-//                   final response = await _firebaseService.addDiagnosis(
-//                     _diagnosisNameController.text,
-//                     _diagnosisDefinitionController.text,
-//                     _selectedSymptoms,
-//                   );
-//                   if (response == 200) {
-//                     ScaffoldMessenger.of(context).showSnackBar(
-//                       const SnackBar(content: Text('Diagnosis added successfully')),
-//                     );
-//                     _diagnosisNameController.clear();
-//                     _diagnosisDefinitionController.clear();
+                  if (symptoms != null && symptoms.isNotEmpty) {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: 20),
+                        const Text('Select Symptoms:'),
+                        SizedBox(
+                          height: 200,
+                          child: ListView.builder(
+                            itemCount: symptoms.length,
+                            itemBuilder: (context, index) {
+                              final symptom = symptoms[index];
+                              return CheckboxListTile(
+                                title: Text(symptom),
+                                value: _selectedSymptoms.contains(symptom),
+                                onChanged: (value) {
+                                  setState(() {
+                                    if (value != null && value) {
+                                      _selectedSymptoms.add(symptom);
+                                    } else {
+                                      _selectedSymptoms.remove(symptom);
+                                    }
+                                  });
+                                },
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    );
+                  } else {
+                    return const Text('No symptoms available');
+                  }
+                }
+              },
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              style: const ButtonStyle(
+                  foregroundColor: MaterialStatePropertyAll<Color>(white),
+                  backgroundColor: MaterialStatePropertyAll<Color>(navy),
+                ),
+              onPressed: () async {
+                if ((_diagnosisNameController.text.isNotEmpty &&
+                    _diagnosisDefinitionController.text.isNotEmpty &&
+                    _selectedSymptoms.isNotEmpty) && await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
+                  final response = await _firebaseService.addDiagnosis(
+                    _diagnosisNameController.text,
+                    _diagnosisDefinitionController.text,
+                    _selectedSymptoms,
+                  );
+                  if (response == 200) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Diagnosis added successfully')),
+                    );
+                    _diagnosisNameController.clear();
+                    _diagnosisDefinitionController.clear();
 
 
 
-//                   } else {
-//                     ScaffoldMessenger.of(context).showSnackBar(
-//                       const SnackBar(content: Text('Failed to add diagnosis')),
-//                     );
-//                   }
-//                 } else if (!await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
-//                   ScaffoldMessenger.of(context).showSnackBar(
-//                     const SnackBar(content: Text('Diagnosis already in database')),
-//                   );
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Failed to add diagnosis')),
+                    );
+                  }
+                } else if (!await _firebaseService.diagnosisNonExistent(_diagnosisNameController.text)) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Diagnosis already in database')),
+                  );
                   
 
-//                 }
-//                 else {
-//                   ScaffoldMessenger.of(context).showSnackBar(
-//                     const SnackBar(content: Text('Please fill all the fields')),
-//                   );
-//                 }
-//               },
-//               child: const Text('Create Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0)),
-//             ),
-//             const SizedBox(height: 20),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }
+                }
+                else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Please fill all the fields')),
+                  );
+                }
+              },
+              child: const Text('Create Diagnosis', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0)),
+            ),
+            const SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
-// //UPDATE
+//UPDATE
 
-// class UpdateDiagnosisPage extends StatefulWidget {
-//   @override
-//   _UpdateDiagnosisPageState createState() => _UpdateDiagnosisPageState();
-// }
+class UpdateDiagnosisPage extends StatefulWidget {
+  @override
+  _UpdateDiagnosisPageState createState() => _UpdateDiagnosisPageState();
+}
 
-// class _UpdateDiagnosisPageState extends State<UpdateDiagnosisPage> {
-//   final _diagnosisUpdateDefinitionController = TextEditingController();
-//   String selectedDiagnosis = '';
-//   String definitionUdate = '';
-//   List<String> symptomsToAdd = [];
-//   List<String> symptomsToDelete = [];
-//   Map<String, bool> symptomCheckedState = {};
+class _UpdateDiagnosisPageState extends State<UpdateDiagnosisPage> {
+  final _diagnosisUpdateDefinitionController = TextEditingController();
+  String selectedDiagnosis = '';
+  String definitionUdate = '';
+  List<String> symptomsToAdd = [];
+  List<String> symptomsToDelete = [];
+  Map<String, bool> symptomCheckedState = {};
 
-//   @override
-//   void initState() {
-//     //_diagnosisUpdateDefinitionController.dispose();
-//     super.initState();
-//     fetchDiagnoses();
-//   }
+  @override
+  void initState() {
+    //_diagnosisUpdateDefinitionController.dispose();
+    super.initState();
+    fetchDiagnoses();
+  }
 
-//    @override
-//   void dispose() {
-//     _diagnosisUpdateDefinitionController.dispose();
-//     super.dispose();
-//   }
+   @override
+  void dispose() {
+    _diagnosisUpdateDefinitionController.dispose();
+    super.dispose();
+  }
 
-//   Future<void> fetchDiagnoses() async {
-//     List<String> diagnoses = await FirebaseService().getAllDiagnosis();
-//     print(diagnoses);
-//     setState(() {
-//       selectedDiagnosis = diagnoses.isNotEmpty ? diagnoses[0] : '';
-//       print("hello");
-//       print(selectedDiagnosis);
-//       print("hello");
-//     });
-//     fetchSymptoms(selectedDiagnosis);
-//   }
+  Future<void> fetchDiagnoses() async {
+    List<Diagnosis> diagnoses = await FirebaseService().getAllDiagnosis();
+    print(diagnoses);
+    setState(() {
+      selectedDiagnosis = diagnoses.isNotEmpty ? diagnoses[0].name : '';
+      print("hello");
+      print(selectedDiagnosis);
+      print("hello");
+    });
+    fetchSymptoms(selectedDiagnosis);
+  }
 
-//   Future<void> fetchSymptoms(String diagnosisName) async {
-//     List<String> allSymptoms =
-//         await FirebaseService().getAllSymptoms();
+  Future<void> fetchSymptoms(String diagnosisName) async {
+    List<String> allSymptoms =
+        await FirebaseService().getAllSymptoms();
 
-//     List<String> currentSymptoms =
-//         await FirebaseService().getSymptomsForDiagnosis(diagnosisName);
+    List<String> currentSymptoms =
+        await FirebaseService().getSymptomsForDiagnosis(diagnosisName);
 
-//     List<String> symptomsForAddition = [];
+    List<String> symptomsForAddition = [];
 
-//     for (String symptom in allSymptoms) {
-//       if (!currentSymptoms.contains(symptom)) {
-//         symptomsForAddition.add(symptom);
-//       }
-//     }
+    for (String symptom in allSymptoms) {
+      if (!currentSymptoms.contains(symptom)) {
+        symptomsForAddition.add(symptom);
+      }
+    }
 
-//     setState(() {
-//       symptomsToDelete = currentSymptoms;
-//       symptomsToAdd = symptomsForAddition;
-//       symptomCheckedState = Map.fromIterable(allSymptoms,
-//           key: (symptom) => symptom, value: (_) => false);
-//     });
-//   }
+    setState(() {
+      symptomsToDelete = currentSymptoms;
+      symptomsToAdd = symptomsForAddition;
+      symptomCheckedState = Map.fromIterable(allSymptoms,
+          key: (symptom) => symptom, value: (_) => false);
+    });
+  }
 
-//   Future<void> updateSymptoms() async {
-//     List<String> symptomsSelectedAdd = [];
-//     List<String> symptomsSelectedDel = [];
+  Future<void> updateSymptoms() async {
+    List<String> symptomsSelectedAdd = [];
+    List<String> symptomsSelectedDel = [];
 
-//     symptomCheckedState.forEach((symptom, isChecked) {
-//       if (isChecked && symptomsToAdd.contains(symptom)) {
-//         symptomsSelectedAdd.add(symptom);
-//       } else if (isChecked && symptomsToDelete.contains(symptom)) {
-//         symptomsSelectedDel.add(symptom);
-//       }
-//     });
+    symptomCheckedState.forEach((symptom, isChecked) {
+      if (isChecked && symptomsToAdd.contains(symptom)) {
+        symptomsSelectedAdd.add(symptom);
+      } else if (isChecked && symptomsToDelete.contains(symptom)) {
+        symptomsSelectedDel.add(symptom);
+      }
+    });
 
-//     for (String symptom in symptomsSelectedAdd) {
-//       await FirebaseService().addSymptomToDiagnosis(
-//         symptom,
-//         selectedDiagnosis,
-//       );
-//     }
+    for (String symptom in symptomsSelectedAdd) {
+      await FirebaseService().addSymptomToDiagnosis(
+        symptom,
+        selectedDiagnosis,
+      );
+    }
 
-//     for (String symptom in symptomsSelectedDel) {
-//       await FirebaseService().removeSymptomFromDiagnosis(
-//         symptom,
-//         selectedDiagnosis,
-//       );
-//     }
+    for (String symptom in symptomsSelectedDel) {
+      await FirebaseService().removeSymptomFromDiagnosis(
+        symptom,
+        selectedDiagnosis,
+      );
+    }
 
-//     setState(() {
-//       symptomsSelectedAdd.clear();
-//       symptomsSelectedDel.clear();
-//     });
+    setState(() {
+      symptomsSelectedAdd.clear();
+      symptomsSelectedDel.clear();
+    });
 
-//     fetchSymptoms(selectedDiagnosis);
-//   }
+    fetchSymptoms(selectedDiagnosis);
+  }
 
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(
-//         title: Text(
-//           'Update Diagnosis',
-//           style: TextStyle(fontSize: 40),
-//         ),
-//       ),
-//       body: Padding(
-//         padding: const EdgeInsets.all(16.0),
-//         child: Column(
-//           crossAxisAlignment: CrossAxisAlignment.start,
-//           children: [
-//             FutureBuilder<List<String>>(
-//               future: FirebaseService().getAllDiagnosis(),
-//               builder: (context, snapshot) {
-//                 if (snapshot.connectionState == ConnectionState.waiting) {
-//                   return CircularProgressIndicator();
-//                 } else if (snapshot.hasError) {
-//                   return Text('Error: ${snapshot.error}');
-//                 } else {
-//                   List<String> diagnoses = snapshot.data ?? [];
-//                   print(diagnoses);
-//                   print(selectedDiagnosis);
-//                   return DropdownButton<String>(
-//                     value: selectedDiagnosis,
-//                     items: diagnoses.map((String diagnosis) {
-//                       return DropdownMenuItem<String>(
-//                         value: diagnosis,
-//                         child: Text(diagnosis),
-//                       );
-//                     }).toList(),
-//                     onChanged: (String? value) {
-//                       if (value != null) {
-//                         setState(() {
-//                           selectedDiagnosis = value;
-//                         });
-//                         fetchSymptoms(selectedDiagnosis);
-//                       }
-//                     },
-//                   );
-//                 }
-//               },
-//             ),
-//             SizedBox(height: 10),
-//             TextField(
-//               controller: _diagnosisUpdateDefinitionController,
-//               decoration: const InputDecoration(
-//                 contentPadding: EdgeInsets.all(20.0),
-//                 labelText: 'Update Definition',
-//                 labelStyle: TextStyle(color: navy),
-//                 filled: true,
-//                 fillColor: boxinsides,
-//                 focusedBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//                 enabledBorder: OutlineInputBorder(
-//                   borderSide: BorderSide(color: boxinsides),
-//                   borderRadius: BorderRadius.all(Radius.circular(40.0))
-//                 ),
-//               ),
-//             ),
-//             // Text(
-//             //   'Update Definition:',
-//             //   style: TextStyle(fontWeight: FontWeight.bold),
-//             // ),
-//             SizedBox(height: 10),
-//             Text(
-//               'Add Symptoms:',
-//               style: TextStyle(fontWeight: FontWeight.bold),
-//             ),
-//             Flexible(
-//               child: ListView.builder(
-//                 itemCount: symptomsToAdd.length,
-//                 itemBuilder: (context, index) {
-//                   final symptom = symptomsToAdd[index];
-//                   return ListTile(
-//                     title: Text(symptom),
-//                     trailing: Checkbox(
-//                       value: symptomCheckedState[symptom] ?? false,
-//                       onChanged: (bool? value) {
-//                         setState(() {
-//                           symptomCheckedState[symptom] = value ?? false;
-//                         });
-//                       },
-//                     ),
-//                   );
-//                 },
-//               ),
-//             ),
-//             SizedBox(height: 10),
-//             Text(
-//               'Remove Symptoms:',
-//               style: TextStyle(fontWeight: FontWeight.bold),
-//             ),
-//             Flexible(
-//               child: ListView.builder(
-//                 itemCount: symptomsToDelete.length,
-//                 itemBuilder: (context, index) {
-//                   final symptom = symptomsToDelete[index];
-//                   return ListTile(
-//                     title: Text(symptom),
-//                     trailing: Checkbox(
-//                       value: symptomCheckedState[symptom] ?? false,
-//                       onChanged: (bool? value) {
-//                         setState(() {
-//                           symptomCheckedState[symptom] = value ?? false;
-//                         });
-//                       },
-//                     ),
-//                   );
-//                 },
-//               ),
-//             ),
-//           ],
-//         ),
-//       ),
-//       floatingActionButton: FloatingActionButton(
-//         onPressed: () async {
-//           if (_diagnosisUpdateDefinitionController.text.isNotEmpty) {
-//             final response = await FirebaseService().updateDiagnosisDef(selectedDiagnosis, _diagnosisUpdateDefinitionController.text);
-//             if (response == 200) {
-//               ScaffoldMessenger.of(context).showSnackBar(
-//                 const SnackBar(content: Text('Diagnosis added successfully')),
-//               );
-//             } else {
-//               ScaffoldMessenger.of(context).showSnackBar(
-//                 const SnackBar(content: Text('Failed to add diagnosis')),
-//               );
-//             }
-//           } 
-//           updateSymptoms();
-//         },
-//         // onPressed: () {
-//         //   updateCategories();
-//         // },
-//         child: Icon(Icons.check),
-//       ),
-//     );
-//   }
-// }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Update Diagnosis',
+          style: TextStyle(fontSize: 40),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FutureBuilder<List<Diagnosis>>(
+              future: FirebaseService().getAllDiagnosis(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+
+                  List<String> diagnoses = [];
+                  for (int i = 0; i < snapshot.data!.length; i++) {
+                    diagnoses.add(snapshot.data![i].name);
+                  }
+                  
+                  print(diagnoses);
+                  print(selectedDiagnosis);
+                  return DropdownButton<String>(
+                    value: selectedDiagnosis,
+                    items: diagnoses.map((String diagnosis) {
+                      return DropdownMenuItem<String>(
+                        value: diagnosis,
+                        child: Text(diagnosis),
+                      );
+                    }).toList(),
+                    onChanged: (String? value) {
+                      if (value != null) {
+                        setState(() {
+                          selectedDiagnosis = value;
+                        });
+                        fetchSymptoms(selectedDiagnosis);
+                      }
+                    },
+                  );
+                }
+              },
+            ),
+            SizedBox(height: 10),
+            TextField(
+              controller: _diagnosisUpdateDefinitionController,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(20.0),
+                labelText: 'Update Definition',
+                labelStyle: TextStyle(color: navy),
+                filled: true,
+                fillColor: boxinsides,
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: boxinsides),
+                  borderRadius: BorderRadius.all(Radius.circular(40.0))
+                ),
+              ),
+            ),
+            // Text(
+            //   'Update Definition:',
+            //   style: TextStyle(fontWeight: FontWeight.bold),
+            // ),
+            SizedBox(height: 10),
+            Text(
+              'Add Symptoms:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            Flexible(
+              child: ListView.builder(
+                itemCount: symptomsToAdd.length,
+                itemBuilder: (context, index) {
+                  final symptom = symptomsToAdd[index];
+                  return ListTile(
+                    title: Text(symptom),
+                    trailing: Checkbox(
+                      value: symptomCheckedState[symptom] ?? false,
+                      onChanged: (bool? value) {
+                        setState(() {
+                          symptomCheckedState[symptom] = value ?? false;
+                        });
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+            SizedBox(height: 10),
+            Text(
+              'Remove Symptoms:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            Flexible(
+              child: ListView.builder(
+                itemCount: symptomsToDelete.length,
+                itemBuilder: (context, index) {
+                  final symptom = symptomsToDelete[index];
+                  return ListTile(
+                    title: Text(symptom),
+                    trailing: Checkbox(
+                      value: symptomCheckedState[symptom] ?? false,
+                      onChanged: (bool? value) {
+                        setState(() {
+                          symptomCheckedState[symptom] = value ?? false;
+                        });
+                      },
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          if (_diagnosisUpdateDefinitionController.text.isNotEmpty) {
+            final response = await FirebaseService().updateDiagnosisDef(selectedDiagnosis, _diagnosisUpdateDefinitionController.text);
+            if (response == 200) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Diagnosis added successfully')),
+              );
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Failed to add diagnosis')),
+              );
+            }
+          } 
+          updateSymptoms();
+        },
+        // onPressed: () {
+        //   updateCategories();
+        // },
+        child: Icon(Icons.check),
+      ),
+    );
+  }
+}
 
 
 
-// class DiagnosisDeletionPage extends StatefulWidget {
-//   const DiagnosisDeletionPage({super.key});
+class DiagnosisDeletionPage extends StatefulWidget {
+  const DiagnosisDeletionPage({super.key});
 
-//   @override
-//   _DiagnosisDeletionPageState createState() => _DiagnosisDeletionPageState();
-// }
+  @override
+  _DiagnosisDeletionPageState createState() => _DiagnosisDeletionPageState();
+}
 
-// class _DiagnosisDeletionPageState extends State<DiagnosisDeletionPage> {
-//   List<String> _selectedDiagnosis= [];
-//   final FirebaseService _firebaseService = FirebaseService();
+class _DiagnosisDeletionPageState extends State<DiagnosisDeletionPage> {
+  List<String> _selectedDiagnosis= [];
+  final FirebaseService _firebaseService = FirebaseService();
 
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(
-//         title: const Text('S.A.M.E'),
-//       ),
-//       body: Padding(
-//         padding: const EdgeInsets.all(15.0),
-//         child: Column(
-//           children: [
-//             const SizedBox(height: 20),
-//             const Text(
-//               'Delete Symptom',
-//               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
-//             ),
-//             const SizedBox(height: 40),
-//             FutureBuilder<List<String>>(
-//               //RAMYA MAKE FIREBASE METHOD
-//               future: _firebaseService.getAllDiagnosis(),
-//               builder: (context, snapshot) {
-//                 if (snapshot.connectionState == ConnectionState.waiting) {
-//                   return const CircularProgressIndicator();
-//                 } else if (snapshot.hasError) {
-//                   return Text('Error: ${snapshot.error}');
-//                 } else {
-//                   List<String>? diagnosis = snapshot.data;
-
-//                   if (diagnosis != null && diagnosis.isNotEmpty) {
-//                     return MultiSelectDialogField<String>(
-//                       backgroundColor: background,
-//                       cancelText: const Text(
-//                         'CANCEL',
-//                         style: TextStyle(fontWeight: FontWeight.bold, color: navy),
-//                       ),
-//                       confirmText: const Text(
-//                         'SELECT',
-//                         style: TextStyle(fontWeight: FontWeight.bold, color: navy),
-//                       ),
-//                       unselectedColor: navy,
-//                       selectedColor: navy,
-//                       items: diagnosis
-//                           .map((diagnosis) => MultiSelectItem<String>(diagnosis, diagnosis))
-//                           .toList(),
-//                       title: const Text("Diagnosis"),
-//                       onConfirm: (values) {
-//                         _selectedDiagnosis = values;
-//                       },
-//                     );
-//                   } else {
-//                     return const Text('No symptoms available');
-//                   }
-//                 }
-//               },
-//             ),
-//             const SizedBox(height: 20),
-//             ElevatedButton(
-//               style: const ButtonStyle(
-//                 foregroundColor: MaterialStatePropertyAll<Color>(white),
-//                 backgroundColor: MaterialStatePropertyAll<Color>(navy),
-//               ),
-//               onPressed: () async {
-//                 if (_selectedDiagnosis.isNotEmpty) {
-//                   for (String diagnosis in _selectedDiagnosis) {
-//                     //RAMYA MAKE FIREBASE METHOD
-//                     await _firebaseService.deleteDiagnosis(diagnosis);
-//                   }
-//                   ScaffoldMessenger.of(context).showSnackBar(
-//                     const SnackBar(
-//                       content: Text('Diagnosis deleted successfully'),
-//                     ),
-//                   );
-//                 } else {
-//                   ScaffoldMessenger.of(context).showSnackBar(
-//                     const SnackBar(
-//                       content: Text('Please select diagnosis to delete'),
-//                     ),
-//                   );
-//                 }
-//               },
-//               child: const Text(
-//                 'Delete Symptoms',
-//                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0),
-//               ),
-//             ),
-//             const SizedBox(height: 20),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('S.A.M.E'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(15.0),
+        child: Column(
+          children: [
+            const SizedBox(height: 20),
+            const Text(
+              'Delete Symptom',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 28.0),
+            ),
+            const SizedBox(height: 40),
+            FutureBuilder<List<Diagnosis>>(
+              //RAMYA MAKE FIREBASE METHOD
+              future: _firebaseService.getAllDiagnosis(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const CircularProgressIndicator();
+                } else if (snapshot.hasError) {
+                  return Text('Error: ${snapshot.error}');
+                } else {
+                  List<String> diagnosis = [];
+                  for (int i = 0; i < snapshot.data!.length; i++) {
+                    diagnosis.add(snapshot.data![i].name);
+                  }
+                  // List<String>? diagnosis = snapshot.data;
+                  if (diagnosis != null && diagnosis.isNotEmpty) {
+                    return MultiSelectDialogField<String>(
+                      backgroundColor: background,
+                      cancelText: const Text(
+                        'CANCEL',
+                        style: TextStyle(fontWeight: FontWeight.bold, color: navy),
+                      ),
+                      confirmText: const Text(
+                        'SELECT',
+                        style: TextStyle(fontWeight: FontWeight.bold, color: navy),
+                      ),
+                      unselectedColor: navy,
+                      selectedColor: navy,
+                      items: diagnosis
+                          .map((diagnosis) => MultiSelectItem<String>(diagnosis, diagnosis))
+                          .toList(),
+                      title: const Text("Diagnosis"),
+                      onConfirm: (values) {
+                        _selectedDiagnosis = values;
+                      },
+                    );
+                  } else {
+                    return const Text('No symptoms available');
+                  }
+                }
+              },
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              style: const ButtonStyle(
+                foregroundColor: MaterialStatePropertyAll<Color>(white),
+                backgroundColor: MaterialStatePropertyAll<Color>(navy),
+              ),
+              onPressed: () async {
+                if (_selectedDiagnosis.isNotEmpty) {
+                  for (String diagnosis in _selectedDiagnosis) {
+                    //RAMYA MAKE FIREBASE METHOD
+                    await _firebaseService.deleteDiagnosis(diagnosis);
+                  }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Diagnosis deleted successfully'),
+                    ),
+                  );
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Please select diagnosis to delete'),
+                    ),
+                  );
+                }
+              },
+              child: const Text(
+                'Delete Symptoms',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.0),
+              ),
+            ),
+            const SizedBox(height: 20),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/s_a_m_e/lib/firebase/firebase_service.dart
+++ b/frontend/s_a_m_e/lib/firebase/firebase_service.dart
@@ -30,11 +30,12 @@ class Category {
 
 class Diagnosis {
   final String name;
+  final String definition;
   final List<String> symptoms;
 
-  Diagnosis({required this.name, required this.symptoms});
+  Diagnosis({required this.name, required this.symptoms, required this.definition});
 
-  Diagnosis.fromJson(Map<String, dynamic> json) : name = json['name'], symptoms = json['symptoms'];
+  Diagnosis.fromJson(Map<String, dynamic> json) : definition = json['definition'], name = json['name'], symptoms = json['symptoms'];
 }
 
 class UserClass {
@@ -715,10 +716,33 @@ Future<Category> getCategory(String categoryName) async {
   Future<void> updateDiagnosis(String name) async {}
   //RAMYA
   Future<void> deleteDiagnosis(String name) async {}
-  //RAMYA
-  Future<List<String>> getAllDiagnosis() async {
-    return ["hi", "bye"];
+  //RAMYA -- whoops Allison did this b/c I needed the method lol -- Need to fix Diagnosis List now though...
+  Future<List<Diagnosis>> getAllDiagnosis() async {
+    try {
+      DataSnapshot snapshot = await _diagnosisRef.get();
+      List<Diagnosis> diagnoses = [];
+
+      if (snapshot.value != null) {
+        Map<dynamic, dynamic> data = snapshot.value as Map<dynamic, dynamic>;
+
+        data.forEach((key, value) {
+          if (value is Map<dynamic, dynamic> && value.containsKey('name')) {
+            String name = value['name'];
+            String definition = value['definition'];
+            List<String> symptoms = List<String>.from(value['symptoms'] ?? []);
+
+            Diagnosis diagnosis = Diagnosis(name: name, symptoms: symptoms, definition: definition);
+            diagnoses.add(diagnosis);
+          }
+        });
+      }
+      return diagnoses;
+    } catch (e) {
+      print('Error getting diagnoses: $e');
+      return [];
+    }
   }
+
   Future<List<String>> getSymptomsForDiagnosis(String diagnosisName) async {
     return ["hi", "bye"];
   }

--- a/frontend/s_a_m_e/lib/user/categorieslist.dart
+++ b/frontend/s_a_m_e/lib/user/categorieslist.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class CategoriesListPage extends StatefulWidget {
   const CategoriesListPage({Key? key}) : super(key: key);

--- a/frontend/s_a_m_e/lib/user/symptomlist.dart
+++ b/frontend/s_a_m_e/lib/user/symptomlist.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
-import 'package:s_a_m_e/account/profilepicture.dart';
+// import 'package:s_a_m_e/account/profilepicture.dart';
 
 class SymptomsListPage extends StatefulWidget {
   const SymptomsListPage({super.key});

--- a/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
+++ b/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:s_a_m_e/userflow/selectSymptoms.dart';
-import 'package:s_a_m_e/user/user_home.dart';
 
 class ChooseCategory extends StatefulWidget {
   const ChooseCategory({Key? key}) : super(key: key);

--- a/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
+++ b/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
@@ -64,7 +64,7 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
             const Divider(thickness: 2),
             const SizedBox(height: 5),
             SizedBox(
-              height: 200,
+              height: MediaQuery.of(context).size.height - 235,
               child: 
                 FutureBuilder<List<Diagnosis>>(
                 future: diagnoses,
@@ -89,7 +89,7 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
                                 ),
                                 child: ListTile(
                                   title: Text(snapshot.data![index].name, style: const TextStyle(fontWeight: FontWeight.bold)),
-                                  subtitle: Text(snapshot.data![index].definition), 
+                                  subtitle: Text(snapshot.data![index].definition, maxLines: 2, overflow: TextOverflow.ellipsis), 
                                 ),
                               ),
                               const SizedBox(height: 10),

--- a/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
+++ b/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
@@ -3,8 +3,9 @@ import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 
 class PotentialDiagnosis extends StatefulWidget {
-  const PotentialDiagnosis({super.key, required this.selectedSymptoms});
+  const PotentialDiagnosis({super.key, required this.selectedSymptoms, required this.category});
 
+  final String category;
   final List<Map<String, dynamic>> selectedSymptoms;
 
   @override
@@ -12,6 +13,23 @@ class PotentialDiagnosis extends StatefulWidget {
 }
 
 class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
+
+  late Future<List<Diagnosis>> diagnoses;
+  List<String> checkedSymptoms = [];
+  String symptoms = "";
+
+  @override
+  void initState() {
+    super.initState();
+    for (int i = 0; i < widget.selectedSymptoms.length; i++) {
+      if (widget.selectedSymptoms[i]["isChecked"] == true) {
+        checkedSymptoms.add(widget.selectedSymptoms[i]["name"]);
+        symptoms += "${widget.selectedSymptoms[i]["name"]}, ";
+      }
+    }
+    symptoms = symptoms.substring(0, symptoms.length - 2);
+    diagnoses = FirebaseService().getAllDiagnosis();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +41,69 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
         padding: const EdgeInsets.all(15),
         child: Column(
           children: [
-            Text("${widget.selectedSymptoms}")
+            RichText(
+              text: TextSpan(
+                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
+                children: <TextSpan>[
+                  const TextSpan(text: "Category", style: TextStyle(fontWeight: FontWeight.bold)),
+                  TextSpan(text: ": ${widget.category}")
+                ]
+              ),
+            ),
+            const SizedBox(height: 5),
+            RichText(
+              text: TextSpan(
+                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
+                children: <TextSpan>[
+                  const TextSpan(text: "Symptoms", style: TextStyle(fontWeight: FontWeight.bold)),
+                  TextSpan(text: ": $symptoms")
+                ]
+              ),
+            ),
+            const SizedBox(height: 10),
+            const Divider(thickness: 2),
+            const SizedBox(height: 5),
+            SizedBox(
+              height: 200,
+              child: 
+                FutureBuilder<List<Diagnosis>>(
+                future: diagnoses,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  } else if (snapshot.hasError) {
+                    return Center(child: Text('Error: ${snapshot.error}'));
+                  } else if (snapshot.hasData) {
+                    return Scrollbar(
+                      trackVisibility: true,
+                      child: ListView.builder(
+                        itemCount: snapshot.data!.length,
+                        itemBuilder: (context, index) {
+                          return Column(
+                            children: <Widget>[
+                              Container( // where the UI starts
+                                decoration: BoxDecoration(
+                                  border: Border.all(color: teal),
+                                  color: boxinsides,
+                                  borderRadius: BorderRadius.circular(15),
+                                ),
+                                child: ListTile(
+                                  title: Text(snapshot.data![index].name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                                  subtitle: Text(snapshot.data![index].definition), 
+                                ),
+                              ),
+                              const SizedBox(height: 10),
+                            ],
+                          );
+                        },
+                      ),
+                    );
+                  } else {
+                    return const Center(child: Text('No diagnoses found'));
+                  }
+                },
+              ),
+            )
           ],
         ),
       ),

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -48,7 +48,7 @@ class _SelectSymptomState extends State<SelectSymptom> {
             const Divider(thickness: 2),
             const SizedBox(height: 5),
             SizedBox(
-              height: 200,
+              height: MediaQuery.of(context).size.height - 205,
               child: ListView.builder(
                 itemCount: widget.category.symptoms.length,
                 itemBuilder: (context, index)

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -96,7 +96,8 @@ class _SelectSymptomState extends State<SelectSymptom> {
           Navigator.push(
             context,
             MaterialPageRoute(
-                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms,)),
+                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms, category:widget.category.name),
+            )
           );
         },
       )

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -103,5 +103,4 @@ class _SelectSymptomState extends State<SelectSymptom> {
       )
     );
   }
-
 }


### PR DESCRIPTION
Additions in this Pull Request:

- UI for potential Diagnosis page is completed
     - currently only displays all diagnosis while we figure out how to filter based on symptoms selected
- the `getAllDiagnosis` method in `firebase_service` was implemented which returns a Diagnosis Object, not just name of the object
     - `editDiagnosis.dart` was modified to accommodate changes to `getAllDiagnosis` 
- warning errors (unused imports) were commented out of their respective files