### PR TITLE
SCRUM-146: Making Categories Expandable Tiles

### DIFF
--- a/frontend/s_a_m_e/ios/Podfile.lock
+++ b/frontend/s_a_m_e/ios/Podfile.lock
@@ -861,7 +861,7 @@ SPEC CHECKSUMS:
   FirebaseFirestore: 171bcbb57a1a348dd171a0d5e382c03ef85a77bb
   FirebaseFirestoreInternal: 7ac1e0c5b4e75aeb898dfe4b1d6d77abbac9eca3
   FirebaseSharedSwift: 19b3f709993d6fa1d84941d41c01e3c4c11eab93
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   fluttertoast: 31b00dabfa7fb7bacd9e7dbee580d7a2ff4bf265
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   "gRPC-C++": 2df8cba576898bdacd29f0266d5236fa0e26ba6a
@@ -876,4 +876,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 
-COCOAPODS: 1.15.0
+COCOAPODS: 1.14.3

--- a/frontend/s_a_m_e/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/s_a_m_e/ios/Runner.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/frontend/s_a_m_e/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/frontend/s_a_m_e/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/frontend/s_a_m_e/lib/user/user_home.dart
+++ b/frontend/s_a_m_e/lib/user/user_home.dart
@@ -6,6 +6,7 @@ import 'package:s_a_m_e/user/symptomlist.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:s_a_m_e/userflow/chooseCategory.dart';
+import 'package:s_a_m_e/userflow/selectSymptoms.dart';
 
 class UserHome extends StatelessWidget {
   const UserHome({super.key});
@@ -236,7 +237,7 @@ Widget build(BuildContext context) {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                      builder: (context) => ChooseCategory()),
+                      builder: (context) => const SelectSymptom()),
                 );
               },
             )

--- a/frontend/s_a_m_e/lib/user/user_home.dart
+++ b/frontend/s_a_m_e/lib/user/user_home.dart
@@ -5,7 +5,6 @@ import 'package:s_a_m_e/account/login.dart';
 import 'package:s_a_m_e/user/symptomlist.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:s_a_m_e/userflow/chooseCategory.dart';
 import 'package:s_a_m_e/userflow/selectSymptoms.dart';
 
 class UserHome extends StatelessWidget {

--- a/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
+++ b/frontend/s_a_m_e/lib/userflow/chooseCategory.dart
@@ -82,12 +82,12 @@ class _ChooseCategoryState extends State<ChooseCategory> {
                             ),
                             child: ElevatedButton(
                               onPressed: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => SelectSymptom(category: snapshot.data![index]),
-                                  ),
-                                );
+                                // Navigator.push(
+                                //   context,
+                                //   MaterialPageRoute(
+                                //     builder: (context) => SelectSymptom(category: snapshot.data![index]),
+                                //   ),
+                                // );
                               },
                               style: ElevatedButton.styleFrom(
                                 foregroundColor: Colors.transparent,

--- a/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
+++ b/frontend/s_a_m_e/lib/userflow/potentialDiagnosis.dart
@@ -3,10 +3,9 @@ import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 
 class PotentialDiagnosis extends StatefulWidget {
-  const PotentialDiagnosis({super.key, required this.selectedSymptoms, required this.category});
+  const PotentialDiagnosis({super.key, required this.selectedSymptoms});
 
-  final String category;
-  final List<Map<String, dynamic>> selectedSymptoms;
+  final Map<String, Map<String, dynamic>> selectedSymptoms;
 
   @override
   State<PotentialDiagnosis> createState() => _PotentialDiagnosisState();
@@ -21,12 +20,14 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
   @override
   void initState() {
     super.initState();
-    for (int i = 0; i < widget.selectedSymptoms.length; i++) {
-      if (widget.selectedSymptoms[i]["isChecked"] == true) {
-        checkedSymptoms.add(widget.selectedSymptoms[i]["name"]);
-        symptoms += "${widget.selectedSymptoms[i]["name"]}, ";
+
+    widget.selectedSymptoms.forEach((key, value) {
+      if (value["isChecked"] == true) {
+        checkedSymptoms.add(key);
+        symptoms += "$key, ";
       }
-    }
+    });
+
     symptoms = symptoms.substring(0, symptoms.length - 2);
     diagnoses = FirebaseService().getAllDiagnosis();
   }
@@ -43,17 +44,7 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
           children: [
             RichText(
               text: TextSpan(
-                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
-                children: <TextSpan>[
-                  const TextSpan(text: "Category", style: TextStyle(fontWeight: FontWeight.bold)),
-                  TextSpan(text: ": ${widget.category}")
-                ]
-              ),
-            ),
-            const SizedBox(height: 5),
-            RichText(
-              text: TextSpan(
-                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
+                style: const TextStyle(fontSize: 16, color: Colors.black, fontFamily: "PT Serif"),
                 children: <TextSpan>[
                   const TextSpan(text: "Symptoms", style: TextStyle(fontWeight: FontWeight.bold)),
                   TextSpan(text: ": $symptoms")

--- a/frontend/s_a_m_e/lib/userflow/search_symptom.dart
+++ b/frontend/s_a_m_e/lib/userflow/search_symptom.dart
@@ -162,17 +162,17 @@ class _SearchSymptomState extends State<SearchSymptom> {
           backgroundColor: MaterialStateProperty.all<Color>(navy),
         ),
         onPressed: () {
-          List<Map<String, dynamic>> checkedSymptomsNames = [];
-          for (var symptom in checkedSymptomNames) {
-            if (symptom["isChecked"]) {
-              checkedSymptomsNames.add(symptom);
-            }
-          }
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptomsNames,)),
-          );
+          // List<Map<String, dynamic>> checkedSymptomsNames = [];
+          // for (var symptom in checkedSymptomNames) {
+          //   if (symptom["isChecked"]) {
+          //     checkedSymptomsNames.add(symptom);
+          //   }
+          // }
+          // Navigator.push(
+          //   context,
+          //   MaterialPageRoute(
+          //       builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptomsNames,)),
+          // );
         },
         child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
       ),

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:s_a_m_e/userflow/potentialDiagnosis.dart';
-import 'package:accordion/accordion.dart';
-import 'package:accordion/controllers.dart';
 
 class SelectSymptom extends StatefulWidget {
   const SelectSymptom({super.key});
@@ -79,29 +77,17 @@ class _SelectSymptomState extends State<SelectSymptom> {
                         } else {
                           return Column(
                             children: [
-                              Accordion(
-                                headerBackgroundColor: navy,
-                                headerBorderColor: navy,
-                                headerBorderColorOpened: Colors.transparent,
-                                headerBackgroundColorOpened: navy,
-                                contentBorderColor: navy,
-                                contentBorderWidth: 2,
-                                contentHorizontalPadding: 20,
-                                scaleWhenAnimating: true,
-                                openAndCloseAnimation: true,
-                                paddingListBottom: 0,
-                                headerPadding:
-                                    const EdgeInsets.symmetric(vertical: 7, horizontal: 15),
-                                sectionOpeningHapticFeedback: SectionHapticFeedback.none,
-                                sectionClosingHapticFeedback: SectionHapticFeedback.none,
+                              ExpansionTile(
+                                collapsedBackgroundColor: navy,
+                                collapsedIconColor: white,
+                                collapsedTextColor: white,
+                                collapsedShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+                                backgroundColor: boxinsides,
+                                title: Text(snapshot.data![index].name, style: const TextStyle(fontWeight: FontWeight.bold),),
                                 children: [
-                                  AccordionSection(
-                                    isOpen: false,
-                                    contentVerticalPadding: 10,
-                                    paddingBetweenClosedSections: 10,
-                                    header: Text(snapshot.data![index].name, style: headerStyle),
-                                    content: SizedBox(
-                                      height: snapshot.data![index].symptoms.length * 20,
+                                  SizedBox(
+                                      height: snapshot.data![index].symptoms.length * 42,
                                       child: ListView.builder(
                                       itemCount: snapshot.data![index].symptoms.length,
                                       itemBuilder: (context, index2) {
@@ -111,6 +97,8 @@ class _SelectSymptomState extends State<SelectSymptom> {
                                           return Column(
                                             children: [
                                               CheckboxListTile(
+                                                visualDensity: VisualDensity(horizontal: -4.0, vertical: -4.0),
+                                                controlAffinity: ListTileControlAffinity.leading,
                                                 title: Text(snapshot.data![index].symptoms[index2]),
                                                 // contentPadding: const EdgeInsets.all(5),
                                                 activeColor: teal,
@@ -127,10 +115,10 @@ class _SelectSymptomState extends State<SelectSymptom> {
                                         }
                                       }
                                     ),
-                                    )
-                                  ),
-                                ]
-                              )
+                                  )
+                                ],
+                              ),
+                              const SizedBox(height: 10),
                             ],
                           );
                         }

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -6,7 +6,7 @@ import 'package:s_a_m_e/userflow/potentialDiagnosis.dart';
 class SelectSymptom extends StatefulWidget {
   const SelectSymptom({super.key, required this.category});
 
-  final Category category;
+  final Category category; // won't need this -- turning categories into same page accordions
 
   @override
   State<SelectSymptom> createState() => _SelectSymptomState();

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
+import 'package:s_a_m_e/userflow/potentialDiagnosis.dart';
 
 class SelectSymptom extends StatefulWidget {
   const SelectSymptom({super.key});
@@ -66,7 +67,12 @@ class _SelectSymptomState extends State<SelectSymptom> {
                         } else {
                           return Column(
                             children: [
-                              ExpansionTile(
+                              Container(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(15),
+                                  border: Border.all(color: teal),
+                                ),
+                                child: ExpansionTile(
                                 collapsedBackgroundColor: navy,
                                 collapsedIconColor: white,
                                 collapsedTextColor: white,
@@ -107,6 +113,7 @@ class _SelectSymptomState extends State<SelectSymptom> {
                                   )
                                 ],
                               ),
+                              ),
                               const SizedBox(height: 10),
                             ],
                           );
@@ -130,12 +137,12 @@ class _SelectSymptomState extends State<SelectSymptom> {
         ),
         child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
         onPressed: () {
-          // Navigator.push(
-          //   context,
-          //   MaterialPageRoute(
-          //       builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms, category:widget.category.name),
-          //   )
-          // );
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms),
+            )
+          );
         },
       )
     );

--- a/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/selectSymptoms.dart
@@ -1,12 +1,13 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
 import 'package:s_a_m_e/userflow/potentialDiagnosis.dart';
+import 'package:accordion/accordion.dart';
+import 'package:accordion/controllers.dart';
 
 class SelectSymptom extends StatefulWidget {
-  const SelectSymptom({super.key, required this.category});
-
-  final Category category; // won't need this -- turning categories into same page accordions
+  const SelectSymptom({super.key});
 
   @override
   State<SelectSymptom> createState() => _SelectSymptomState();
@@ -14,15 +15,36 @@ class SelectSymptom extends StatefulWidget {
 
 class _SelectSymptomState extends State<SelectSymptom> {
 
+  late Future<List<Category>> categories;
+  List<Category> categoriesList = [];
+
+  // can make the list of isChecked a list of all the symptoms (one symptom to a category?)
+
   List<Map<String, dynamic>> checkedSymptoms = [];
+  bool isChecked = false;
+
+  static const headerStyle = TextStyle(
+      color: Color(0xffffffff), fontSize: 18, fontWeight: FontWeight.bold);
+
+  static const contentStyle = TextStyle(
+      color: Color(0xff999999), fontSize: 14, fontWeight: FontWeight.normal);
+
+  void categoryList() async {
+    categoriesList = await categories;
+  }
 
   @override
   void initState() {
     super.initState();
-    for (int i = 0; i < widget.category.symptoms.length; i++) {
-      checkedSymptoms.add({"name": widget.category.symptoms[i], "isChecked": false}); // this doesn't work...
+    categories = FirebaseService().getAllCategories();
+    categoryList();
+
+    if (categoriesList.length > 0){
+      for (int i = 0; i < categoriesList.length; i++) {
+        checkedSymptoms.add({"name": categoriesList[i].name, "isChecked": false}); // this doesn't work...
+      }
+      print(checkedSymptoms);
     }
-    print(checkedSymptoms);
   }
 
   @override
@@ -33,57 +55,133 @@ class _SelectSymptomState extends State<SelectSymptom> {
       ),
       body: Padding(
         padding: const EdgeInsets.all(15),
-        child: Column(
-          children: [
-            RichText(
-              text: TextSpan(
-                style: const TextStyle(fontSize: 20, color: Colors.black, fontFamily: "PT Serif"),
-                children: <TextSpan>[
-                  const TextSpan(text: "Category", style: TextStyle(fontWeight: FontWeight.bold)),
-                  TextSpan(text: ": ${widget.category.name}")
-                ]
-              )
-            ),
-            const SizedBox(height: 10),
-            const Divider(thickness: 2),
-            const SizedBox(height: 5),
-            SizedBox(
-              height: MediaQuery.of(context).size.height - 205,
-              child: ListView.builder(
-                itemCount: widget.category.symptoms.length,
-                itemBuilder: (context, index)
-                {
-                  if (widget.category.symptoms.isEmpty) {
-                    return const Center(child: Text('No Symptoms Found'));
-                  } else {
-                    print(checkedSymptoms);
-                    return Column(
-                      children: [
-                        CheckboxListTile(
-                        value: checkedSymptoms[index]["isChecked"],
-                        title: Text(widget.category.symptoms[index]),
-                        controlAffinity: ListTileControlAffinity.leading,
-                        activeColor: navy,
-                        tileColor: boxinsides,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(15),
-                          side: const BorderSide(color: teal)
-                          ),
-                        onChanged: (value) {
-                          setState(() {
-                            checkedSymptoms[index]["isChecked"] = value!;
-                          });
-                        },
-                      ),
-                      const SizedBox(height: 10,)
-                      ],
-                    );
-                  }   
-                }
-              ),
-            )
-          ],
+        child: FutureBuilder(
+          future: categories,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (snapshot.hasError) {
+              return Center(child: Text('Error: ${snapshot.error}'));
+            } else if (snapshot.hasData) {
+              return Column(
+                children: [
+                  const Text("Select symptoms from the categories below"),
+                  const SizedBox(height: 10),
+                  const Divider(thickness: 2),
+                  const SizedBox(height: 5),
+                  SizedBox(
+                    height: 600,
+                    child: ListView.builder(
+                      itemCount: categoriesList.length,
+                      itemBuilder: (context, index) {
+                        if (categoriesList.isEmpty) {
+                          return const Center(child: Text('No Symptoms Found'));
+                        } else {
+                          return Column(
+                            children: [
+                              Accordion(
+                                headerBackgroundColor: navy,
+                                headerBorderColor: navy,
+                                headerBorderColorOpened: Colors.transparent,
+                                headerBackgroundColorOpened: navy,
+                                contentBorderColor: navy,
+                                contentBorderWidth: 2,
+                                contentHorizontalPadding: 20,
+                                scaleWhenAnimating: true,
+                                openAndCloseAnimation: true,
+                                paddingListBottom: 0,
+                                headerPadding:
+                                    const EdgeInsets.symmetric(vertical: 7, horizontal: 15),
+                                sectionOpeningHapticFeedback: SectionHapticFeedback.none,
+                                sectionClosingHapticFeedback: SectionHapticFeedback.none,
+                                children: [
+                                  AccordionSection(
+                                    isOpen: false,
+                                    contentVerticalPadding: 10,
+                                    paddingBetweenClosedSections: 10,
+                                    header: Text(snapshot.data![index].name, style: headerStyle),
+                                    content: SizedBox(
+                                      height: snapshot.data![index].symptoms.length * 20,
+                                      child: ListView.builder(
+                                      itemCount: snapshot.data![index].symptoms.length,
+                                      itemBuilder: (context, index2) {
+                                        if (snapshot.data![index].symptoms.isEmpty) {
+                                          return const Center(child: Text('No Symptoms Found'));
+                                        } else {
+                                          return Column(
+                                            children: [
+                                              CheckboxListTile(
+                                                title: Text(snapshot.data![index].symptoms[index2]),
+                                                // contentPadding: const EdgeInsets.all(5),
+                                                activeColor: teal,
+                                                value: isChecked,
+                                                onChanged: (bool? value) {
+                                                  setState(() {
+                                                    isChecked = value!;
+                                                  });
+                                                }
+                                              )
+                                              // Text(snapshot.data![index].symptoms[index2])
+                                            ],
+                                          );
+                                        }
+                                      }
+                                    ),
+                                    )
+                                  ),
+                                ]
+                              )
+                            ],
+                          );
+                        }
+                      }
+                    ),
+                  )
+                ],
+              );
+            } else {
+              return const Center(child: Text('No symptoms found'));
+            }
+          }
         )
+        
+        
+            // SizedBox(
+            //   height: 400,
+            //   child: ListView.builder(
+            //     itemCount: widget.category.symptoms.length,
+            //     itemBuilder: (context, index)
+            //     {
+            //       if (widget.category.symptoms.isEmpty) {
+            //         return const Center(child: Text('No Symptoms Found'));
+            //       } else {
+            //         print(checkedSymptoms);
+            //         return Column(
+            //           children: [
+            //             CheckboxListTile(
+            //             value: checkedSymptoms[index]["isChecked"],
+            //             title: Text(widget.category.symptoms[index]),
+            //             controlAffinity: ListTileControlAffinity.leading,
+            //             activeColor: navy,
+            //             tileColor: boxinsides,
+            //             shape: RoundedRectangleBorder(
+            //               borderRadius: BorderRadius.circular(15),
+            //               side: const BorderSide(color: teal)
+            //               ),
+            //             onChanged: (value) {
+            //               setState(() {
+            //                 checkedSymptoms[index]["isChecked"] = value!;
+            //               });
+            //             },
+            //           ),
+            //           const SizedBox(height: 10,)
+            //           ],
+            //         );
+            //       }   
+            //     }
+            //   ),
+            // )
+
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       floatingActionButton: ElevatedButton(
@@ -93,12 +191,12 @@ class _SelectSymptomState extends State<SelectSymptom> {
         ),
         child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
         onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms, category:widget.category.name),
-            )
-          );
+          // Navigator.push(
+          //   context,
+          //   MaterialPageRoute(
+          //       builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms, category:widget.category.name),
+          //   )
+          // );
         },
       )
     );

--- a/frontend/s_a_m_e/pubspec.lock
+++ b/frontend/s_a_m_e/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.16"
+  accordion:
+    dependency: "direct main"
+    description:
+      name: accordion
+      sha256: "0eca3d1c619c6df63d6e384010fd2ef1164e7385d7102f88a6b56f658f160cd0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
@@ -240,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.2.4"
+  get:
+    dependency: transitive
+    description:
+      name: get
+      sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.6"
   http:
     dependency: "direct main"
     description:
@@ -328,6 +344,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -340,26 +380,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -380,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -392,6 +432,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  scroll_to_index:
+    dependency: transitive
+    description:
+      name: scroll_to_index
+      sha256: b707546e7500d9f070d63e5acf74fd437ec7eeeb68d3412ef7b0afada0b4f176
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -461,6 +509,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   web:
     dependency: transitive
     description:
@@ -471,4 +527,4 @@ packages:
     version: "0.3.0"
 sdks:
   dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.13.0"

--- a/frontend/s_a_m_e/pubspec.yaml
+++ b/frontend/s_a_m_e/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
 
   # The below dependency makes it so users can upload images for their profile pictures
   image_picker: ^0.8.3
+  accordion: ^2.6.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Additions in this pull request:

- combine the `chooseCategory` and `selectSymptoms` pages (essentially)
- made the `selectSymptoms` display into a a dropdown of categories
     - each dropdown contains the symptoms associated with the category
- one symptom can be associated with multiple categories & will show up in both dropdowns
     - if the symptom is selected in one category, it will be selected in all other categories it's associated in as well
- update `potentialDiagnosis.dart` to match formatting of `selectSymptoms.dart`

Note:

- can delete the `chooseCategory.dart` file as it is no longer in use
- will likely need to reimplement the `searchSymptom` functionality