### PR TITLE
SCRUM-129: Diagnosis Focus Page

### DIFF
--- a/frontend/s_a_m_e/lib/user/user_home.dart
+++ b/frontend/s_a_m_e/lib/user/user_home.dart
@@ -129,7 +129,7 @@ class UserHome extends StatelessWidget {
                                 onPressed: () {
                                   Navigator.of(context).pop();
                                 },
-                                child: const Text("OK"),
+                                child: const Text("OK", style: TextStyle(color: navy),),
                               ),
                             ],
                           );

--- a/frontend/s_a_m_e/lib/userflow/diagnosis_page.dart
+++ b/frontend/s_a_m_e/lib/userflow/diagnosis_page.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:s_a_m_e/colors.dart';
+import 'package:s_a_m_e/firebase/firebase_service.dart';
+
+class DiagnosisPage extends StatefulWidget {
+  const DiagnosisPage({super.key, required this.diagnosis});
+
+  // take the diagnosis selected
+  final Diagnosis diagnosis;
+
+  @override
+  State<DiagnosisPage> createState() => DiagnosisPageState();
+}
+
+class DiagnosisPageState extends State<DiagnosisPage> {
+  
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      initialIndex: 0,
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Potential Diagnosis", style: TextStyle(fontSize: 32.0)),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(15),
+          child: Column(
+            children: [
+              RichText(
+                text: TextSpan(
+                  style: const TextStyle(fontSize: 22, color: Colors.black, fontFamily: "PT Serif"),
+                  children: <TextSpan>[
+                    const TextSpan(text: "Diagnosis", style: TextStyle(fontWeight: FontWeight.bold)),
+                    TextSpan(text: ": ${widget.diagnosis.name}")
+                  ]
+                ),
+              ),
+              const SizedBox(height: 10,),
+              const TabBar(
+                indicatorColor: navy,
+                labelColor: navy,
+                overlayColor: MaterialStatePropertyAll<Color>(boxinsides),
+                tabs: <Widget> [
+                  Tab(
+                    child: Text("About Diagnosis", style: TextStyle(fontWeight: FontWeight.bold),),
+                  ),
+                  Tab(
+                    child: Text("Next Steps", style: TextStyle(fontWeight: FontWeight.bold),),
+                  )
+                ]
+              ),
+              
+              Expanded(
+                child: TabBarView(
+                  children: <Widget>[
+                    // about the diagnosis tab
+                    Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const SizedBox(height: 15,),
+                          RichText(
+                            text: TextSpan(
+                              style: const TextStyle(fontSize: 16, color: Colors.black, fontFamily: "PT Serif"),
+                              children: <TextSpan>[
+                                const TextSpan(text: "Name", style: TextStyle(fontWeight: FontWeight.bold)),
+                                TextSpan(text: ": ${widget.diagnosis.name}")
+                              ]
+                            ),
+                          ),
+                          const SizedBox(height: 15,),
+                          RichText(
+                            text: TextSpan(
+                              style: const TextStyle(fontSize: 16, color: Colors.black, fontFamily: "PT Serif"),
+                              children: <TextSpan>[
+                                const TextSpan(text: "Description", style: TextStyle(fontWeight: FontWeight.bold)),
+                                TextSpan(text: ": ${widget.diagnosis.definition}")
+                              ]
+                            ),
+                          ),
+                          const SizedBox(height: 15,),
+                          const Text("Symptoms:", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),),
+                          const SizedBox(height: 5,),
+                          SizedBox(
+                            height: widget.diagnosis.symptoms.length * 25,
+                            child: ListView.builder(
+                              itemCount: widget.diagnosis.symptoms.length,
+                              itemBuilder: (context, index) {
+                                return Row(
+                                  children:[
+                                    const Text("\t\t \u2022", style: TextStyle(fontSize: 16),), //bullet text
+                                    const SizedBox(width: 10,), //space between bullet and text
+                                    Expanded( 
+                                      child: Text(widget.diagnosis.symptoms[index], style: const TextStyle(fontSize: 16),), //text
+                                    )
+                                  ]
+                                );
+                              }
+                            )
+                          ),
+                          const SizedBox(height: 15,),
+                          const Text("Signs:", style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),),
+                        ]
+                      ),
+                    ),
+                    
+                    // next steps tab
+                    const Padding(
+                      padding: EdgeInsets.all(15),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: 15,),
+                          Text("add next steps to database")
+                        ],
+                      ),
+                    )
+                  ]
+                )
+              )
+            ],
+          )
+        )
+      ),
+    );
+  }
+}

--- a/frontend/s_a_m_e/lib/userflow/potential_diagnosis.dart
+++ b/frontend/s_a_m_e/lib/userflow/potential_diagnosis.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:s_a_m_e/colors.dart';
 import 'package:s_a_m_e/firebase/firebase_service.dart';
+import 'package:s_a_m_e/userflow/diagnosis_page.dart';
 
 class PotentialDiagnosis extends StatefulWidget {
   const PotentialDiagnosis({super.key, required this.selectedSymptoms});
@@ -54,8 +57,8 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
             const SizedBox(height: 10),
             const Divider(thickness: 2),
             const SizedBox(height: 5),
-            SizedBox(
-              height: MediaQuery.of(context).size.height - 235,
+            Expanded(
+              // height: MediaQuery.of(context).size.height - 235,
               child: 
                 FutureBuilder<List<Diagnosis>>(
                 future: diagnoses,
@@ -80,7 +83,27 @@ class _PotentialDiagnosisState extends State<PotentialDiagnosis> {
                                 ),
                                 child: ListTile(
                                   title: Text(snapshot.data![index].name, style: const TextStyle(fontWeight: FontWeight.bold)),
-                                  subtitle: Text(snapshot.data![index].definition, maxLines: 2, overflow: TextOverflow.ellipsis), 
+                                  subtitle: Text(snapshot.data![index].definition, maxLines: 2, overflow: TextOverflow.ellipsis),
+                                  trailing: GestureDetector(
+                                    onTap: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => DiagnosisPage(diagnosis: snapshot.data![index]),
+                                        )
+                                      );
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.all(5),
+                                      decoration: BoxDecoration(
+                                          borderRadius: BorderRadius.circular(20),
+                                          border: Border.all(
+                                            color: navy,
+                                            width: 1.0,
+                                          )),
+                                      child: const Icon(Icons.arrow_forward_ios_outlined, color: navy),
+                                    ),
+                                  ),
                                 ),
                               ),
                               const SizedBox(height: 10),

--- a/frontend/s_a_m_e/lib/userflow/select_symptoms.dart
+++ b/frontend/s_a_m_e/lib/userflow/select_symptoms.dart
@@ -33,6 +33,17 @@ class _SelectSymptomState extends State<SelectSymptom> {
     }
   }
 
+  int amountChecked(Map<String, Map<String, dynamic>> list) {
+    int selectedCount = 0;
+    list.forEach((key, value) {
+      if (value["isChecked"] == true) {
+        selectedCount++;
+      }
+    });
+    
+    return selectedCount;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -55,8 +66,8 @@ class _SelectSymptomState extends State<SelectSymptom> {
                   const SizedBox(height: 10),
                   const Divider(thickness: 2),
                   const SizedBox(height: 5),
-                  SizedBox(
-                    height: 600,
+                  Expanded(
+                    // height: 600,
                     child: ListView.builder(
                       itemCount: snapshot.data!.length,
                       itemBuilder: (context, index) {
@@ -65,17 +76,13 @@ class _SelectSymptomState extends State<SelectSymptom> {
                         } else {
                           return Column(
                             children: [
-                              Container(
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(15),
-                                  border: Border.all(color: teal),
-                                ),
-                                child: ExpansionTile(
+                              ExpansionTile(
+                                iconColor: navy,
                                 collapsedBackgroundColor: navy,
                                 collapsedIconColor: white,
                                 collapsedTextColor: white,
-                                collapsedShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
-                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+                                collapsedShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15), side: const BorderSide(color: navy)),
+                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15), side: const BorderSide(color: teal)),
                                 backgroundColor: boxinsides,
                                 title: Text(snapshot.data![index].name, style: const TextStyle(fontWeight: FontWeight.bold),),
                                 children: [
@@ -111,7 +118,6 @@ class _SelectSymptomState extends State<SelectSymptom> {
                                   )
                                 ],
                               ),
-                              ),
                               const SizedBox(height: 10),
                             ],
                           );
@@ -135,12 +141,34 @@ class _SelectSymptomState extends State<SelectSymptom> {
         ),
         child: const Text('Get Potential Diagnoses', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
         onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-                builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms),
-            )
-          );
+          int count = amountChecked(checkedSymptoms);
+          if (count > 0) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => PotentialDiagnosis(selectedSymptoms:checkedSymptoms),
+              )
+            );
+          } else {
+            showDialog(
+              context: context,
+              builder: (BuildContext context) {
+                return AlertDialog(
+                  backgroundColor: background,
+                  title: const Text('Error'),
+                  content: const Text('Please choose at least one symptom.'),
+                  actions: [
+                    TextButton(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                      child: const Text("OK", style: TextStyle(color: navy),),
+                    ),
+                  ],
+                );
+              }
+            );
+          }
         },
       )
     );


### PR DESCRIPTION
Additions in this pull request:

- the ability to view more regarding a diagnosis in `diagnosis_page.dart`
- in `diagnosis_page` a user can view all the information about the diagnosis selected including
     - a diagnosis' name, description, symptoms, and signs in the "About Description" tab
     - the diagnosis' next steps under the "Next Steps" tab
- throw error message in `select_symptoms` page to make sure a user selects at least one symptom